### PR TITLE
Better 'Watch Streak' strategy in priority system

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://help.twitch.tv/s/article/channel-points-guide
 - Final report with all the datas
 - Rewrite the entire code using classe instead of module with global variables
 - Automatic download the followers list and use as input
+- Better 'Watch Streak' strategy in priority system [#11](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/11)
 - Place the bet / make prediction and won or lose (good luck) your channel points! **(CURRENTLY IN BETA)**
 
 For the bet system the script use Selenium. Could be usefull understand how to MakePrediction usign a [POST] request. I've also write a [poc](/TwitchChannelPointsMiner/classes/Twitch.py#L160) but I don't know how to calculate/create the transactionID. Any helps are welcome
@@ -145,6 +146,7 @@ twitch_miner = TwitchChannelPointsMiner(
     username="your-twitch-username",
     make_predictions=True,              # If you want to Bet / Make prediction | The browser will never start
     follow_raid=True,                   # Follow raid to obtain more points
+    watch_streak=True,                  # If a streamer go online change the priotiry of streamers array and catch the watch screak. Issue #11
     logger_settings=LoggerSettings(
         save=True,                      # If you want to save logs in file (suggested)
         console_level=logging.INFO,     # Level of logs - use logging.DEBUG for more info)
@@ -169,6 +171,7 @@ twitch_miner.mine(
     ["streamer1", "streamer2"],         # Array of streamers (order = priority)
     followers=False                     # Automatic download the list of your followers
 )
+
 
 ```
 You can also use all the default values except for your username obv. Short version:

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -38,6 +38,7 @@ class TwitchChannelPointsMiner:
         username: str,
         make_predictions: bool = True,
         follow_raid: bool = True,
+        watch_streak: bool = False,
         logger_settings: LoggerSettings = LoggerSettings(),
         browser_settings: BrowserSettings = BrowserSettings(),
         bet_settings: BetSettings = BetSettings(),
@@ -46,6 +47,7 @@ class TwitchChannelPointsMiner:
         self.twitch = Twitch(self.username)
         self.twitch_browser = None
         self.follow_raid = follow_raid
+        self.watch_streak = watch_streak
         self.streamers = []
         self.events_predictions = {}
         self.minute_watcher_thread = None
@@ -135,7 +137,11 @@ class TwitchChannelPointsMiner:
                 self.twitch_browser.init()
 
             self.minute_watcher_thread = threading.Thread(
-                target=self.twitch.send_minute_watched_events, args=(self.streamers,)
+                target=self.twitch.send_minute_watched_events,
+                args=(
+                    self.streamers,
+                    self.watch_streak,
+                ),
             )
             # self.minute_watcher_thread.daemon = True
             self.minute_watcher_thread.start()
@@ -186,6 +192,8 @@ class TwitchChannelPointsMiner:
                     WebSocketsPool.handle_websocket_reconnection(self.ws_pool.ws)
 
     def end(self, signum, frame):
+        logger.info("CTRL+C Detected! Please wait, just a moment\n")
+
         if self.twitch_browser is not None:
             self.twitch_browser.browser.quit()
 

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -223,11 +223,12 @@ class TwitchChannelPointsMiner:
             print("")
             logger.info(f"{self.bet_settings}", extra={"emoji": ":bar_chart:"})
             for event_id in self.events_predictions:
-                self.events_predictions[event_id].set_less_printing(False)
-                logger.info(
-                    f"{self.events_predictions[event_id].print_recap()}",
-                    extra={"emoji": ":bar_chart:"},
-                )
+                if self.events_predictions[event_id].bet_confirmed is True:
+                    self.events_predictions[event_id].set_less_printing(False)
+                    logger.info(
+                        f"{self.events_predictions[event_id].print_recap()}",
+                        extra={"emoji": ":bar_chart:"},
+                    )
             print("")
 
         for streamer_index in range(0, len(self.streamers)):

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -192,7 +192,7 @@ class TwitchChannelPointsMiner:
                     WebSocketsPool.handle_websocket_reconnection(self.ws_pool.ws)
 
     def end(self, signum, frame):
-        logger.info("CTRL+C Detected! Please wait, just a moment\n")
+        logger.info("CTRL+C Detected! Please wait, just a moment")
 
         if self.twitch_browser is not None:
             self.twitch_browser.browser.quit()

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -122,7 +122,9 @@ class TwitchChannelPointsMiner:
 
             for streamer in self.streamers:
                 time.sleep(random.uniform(0.3, 0.7))
-                self.twitch.load_channel_points_context(streamer, less_printing=self.logger_settings.less)
+                self.twitch.load_channel_points_context(
+                    streamer, less_printing=self.logger_settings.less
+                )
                 self.twitch.check_streamer_online(streamer)
             self.original_streamers = copy.deepcopy(self.streamers)
 

--- a/TwitchChannelPointsMiner/__init__.py
+++ b/TwitchChannelPointsMiner/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.3.1"
+__version__ = "2.3.5"
 from .TwitchChannelPointsMiner import TwitchChannelPointsMiner  # noqa: F401

--- a/TwitchChannelPointsMiner/__init__.py
+++ b/TwitchChannelPointsMiner/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.2.5"
+__version__ = "2.3.1"
 from .TwitchChannelPointsMiner import TwitchChannelPointsMiner  # noqa: F401

--- a/TwitchChannelPointsMiner/classes/Bet.py
+++ b/TwitchChannelPointsMiner/classes/Bet.py
@@ -4,6 +4,8 @@ import copy
 from enum import Enum, auto
 from millify import millify
 
+from TwitchChannelPointsMiner.utils import float_round
+
 logger = logging.getLogger(__name__)
 
 
@@ -29,10 +31,6 @@ class BetSettings:
 
     def __repr__(self):
         return f"BetSettings(Strategy={self.strategy}, Percentage={self.percentage}, PercentageGap={self.percentage_gap}, MaxPoints={self.max_points}"
-
-
-def float_round(value):
-    return round(float(value), 2)
 
 
 class Bet:

--- a/TwitchChannelPointsMiner/classes/EventPrediction.py
+++ b/TwitchChannelPointsMiner/classes/EventPrediction.py
@@ -1,5 +1,6 @@
 from TwitchChannelPointsMiner.classes.Bet import Bet, BetSettings
 from TwitchChannelPointsMiner.classes.Streamer import Streamer
+from TwitchChannelPointsMiner.utils import float_round
 
 
 class EventPrediction:
@@ -18,7 +19,7 @@ class EventPrediction:
         self.streamer = streamer
 
         self.event_id = event_id
-        self.title = title
+        self.title = title.strip()
         self.created_at = created_at
         self.prediction_window_seconds = prediction_window_seconds
         self.status = status
@@ -46,10 +47,10 @@ class EventPrediction:
         )
 
     def elapsed(self, timestamp):
-        return round(float((timestamp - self.created_at).total_seconds()), 2)
+        return float_round((timestamp - self.created_at).total_seconds())
 
     def closing_bet_after(self, timestamp):
-        return round(float(self.prediction_window_seconds - self.elapsed(timestamp)), 2)
+        return float_round(self.prediction_window_seconds - self.elapsed(timestamp))
 
     def print_recap(self):
         return f"{self}\n\t\t{self.streamer}\n\t\t{self.bet}\n\t\tResult: {self.final_result}"

--- a/TwitchChannelPointsMiner/classes/EventPrediction.py
+++ b/TwitchChannelPointsMiner/classes/EventPrediction.py
@@ -25,6 +25,7 @@ class EventPrediction:
         self.final_result = {}
 
         self.box_fillable = False
+        self.bet_confirmed = False
         self.bet_placed = False
         self.bet = Bet(outcomes, bet_settings)
 

--- a/TwitchChannelPointsMiner/classes/Logger.py
+++ b/TwitchChannelPointsMiner/classes/Logger.py
@@ -26,8 +26,8 @@ class EmojiFormatter(logging.Formatter):
             )
             record.emoji_is_present = True
 
-        if u"\u2192" in record.msg and self.print_emoji is False:
-            record.msg = record.msg.replace(u"\u2192", "-->")
+        if "\u2192" in record.msg and self.print_emoji is False:
+            record.msg = record.msg.replace("\u2192", "-->")
 
         return super().format(record)
 

--- a/TwitchChannelPointsMiner/classes/Message.py
+++ b/TwitchChannelPointsMiner/classes/Message.py
@@ -18,10 +18,10 @@ class Message:
         self.identifier = f"{self.type}.{self.topic}.{self.channel_id}"
 
     def __repr__(self):
-        return self.message
+        return f"{self.message}"
 
     def __str__(self):
-        return self.message
+        return f"{self.message}"
 
     def __get_timestamp(self):
         return (

--- a/TwitchChannelPointsMiner/classes/Message.py
+++ b/TwitchChannelPointsMiner/classes/Message.py
@@ -1,0 +1,54 @@
+import json
+
+from TwitchChannelPointsMiner.utils import server_time
+
+
+class Message:
+    def __init__(self, data):
+        self.topic, self.topic_user = data["topic"].split(".")
+
+        self.message = json.loads(data["message"])
+        self.type = self.message["type"]
+
+        self.data = self.message["data"] if "data" in self.message else None
+
+        self.timestamp = self.__get_timestamp()
+        self.channel_id = self.__get_channel_id()
+
+        self.identifier = f"{self.type}.{self.topic}.{self.channel_id}"
+
+    def __repr__(self):
+        return self.message
+
+    def __str__(self):
+        return self.message
+
+    def __get_timestamp(self):
+        return (
+            server_time(self.message)
+            if self.data is None
+            else (
+                self.data["timestamp"]
+                if "timestamp" in self.data
+                else server_time(self.data)
+            )
+        )
+
+    def __get_channel_id(self):
+        return (
+            self.topic_user
+            if self.data is None
+            else (
+                self.data["prediction"]["channel_id"]
+                if "prediction" in self.data
+                else (
+                    self.data["claim"]["channel_id"]
+                    if "claim" in self.data
+                    else (
+                        self.data["channel_id"]
+                        if "channel_id" in self.data
+                        else self.topic_user
+                    )
+                )
+            )
+        )

--- a/TwitchChannelPointsMiner/classes/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/Streamer.py
@@ -13,16 +13,15 @@ class Streamer:
         self.username = username
         self.channel_id = channel_id
         self.is_online = False
+        self.stream_up = 0
         self.online_at = 0
         self.offline_at = 0
         self.channel_points = 0
-
         self.minute_watched_requests = None
-        self.minute_watched = 0
-        self.last_minute_watched = 0
+
+        self.__init_watch_streak()
 
         self.raid = None
-        self.watch_streak_missing = True
         self.history = {}
 
         self.streamer_url = f"{TWITCH_URL}/{self.username}"
@@ -45,31 +44,26 @@ class Streamer:
         )
 
     def set_offline(self):
-        # Print the offline message only If we are recently online or we are in bootstrap phase (offline_at == 0)
-        if self.is_online is True or self.offline_at == 0:
-            logger.info(f"{self} is Offline!", extra={"emoji": ":sleeping:"})
-
         if self.is_online is True:
             self.offline_at = time.time()
             self.is_online = False
+
+        logger.info(f"{self} is Offline!", extra={"emoji": ":sleeping:"})
 
     def set_online(self):
         if self.is_online is False:
             self.online_at = time.time()
             self.is_online = True
-            # Watch streak variables
-            self.watch_streak_missing = True
-            self.minute_watched = 0
-            self.last_minute_watched = 0
+            self.__init_watch_streak()
 
         logger.info(f"{self} is Online!", extra={"emoji": ":partying_face:"})
 
     def update_minute_watched(self):
-        if self.last_minute_watched != 0:
+        if self.minute_watched_timestamp != 0:
             self.minute_watched += round(
-                (time.time() - self.last_minute_watched) / 60, 5
+                (time.time() - self.minute_watched_timestamp) / 60, 5
             )
-        self.last_minute_watched = time.time()
+        self.minute_watched_timestamp = time.time()
 
     def print_history(self):
         return ", ".join(
@@ -90,3 +84,8 @@ class Streamer:
 
     def set_less_printing(self, value):
         self.less_printing = value
+
+    def __init_watch_streak(self):
+        self.watch_streak_missing = True
+        self.minute_watched = 0
+        self.minute_watched_timestamp = 0

--- a/TwitchChannelPointsMiner/classes/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/Streamer.py
@@ -1,6 +1,8 @@
 import time
 import logging
 
+from TwitchChannelPointsMiner.constants import TWITCH_URL
+
 logger = logging.getLogger(__name__)
 
 
@@ -21,8 +23,8 @@ class Streamer:
         self.watch_streak_missing = True
         self.history = {}
 
-        self.streamer_url = f"https://www.twitch.tv/{self.username}"
-        self.chat_url = f"https://www.twitch.tv/popout/{self.username}/chat?popout="
+        self.streamer_url = f"{TWITCH_URL}/{self.username}"
+        self.chat_url = f"{TWITCH_URL}/popout/{self.username}/chat?popout="
 
         self.less_printing = less_printing
 
@@ -41,11 +43,13 @@ class Streamer:
         )
 
     def set_offline(self):
+        # Print the offline message only If we are recently online or we are in bootstrap phase (offline_at == 0)
+        if self.is_online is True or self.offline_at == 0:
+            logger.info(f"{self} is Offline!", extra={"emoji": ":sleeping:"})
+
         if self.is_online is True:
             self.offline_at = time.time()
             self.is_online = False
-
-        logger.info(f"{self} is Offline!", extra={"emoji": ":sleeping:"})
 
     def set_online(self):
         if self.is_online is False:

--- a/TwitchChannelPointsMiner/classes/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/Streamer.py
@@ -89,3 +89,6 @@ class Streamer:
         self.watch_streak_missing = True
         self.minute_watched = 0
         self.minute_watched_timestamp = 0
+
+    def stream_up_elapsed(self):
+        return self.stream_up == 0 or ((time.time() - self.stream_up) > 120)

--- a/TwitchChannelPointsMiner/classes/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/Streamer.py
@@ -12,8 +12,13 @@ class Streamer:
         self.online_at = 0
         self.offline_at = 0
         self.channel_points = 0
+
         self.minute_watched_requests = None
+        self.minute_watched = 0
+        self.last_minute_watched = 0
+
         self.raid = None
+        self.watch_streak_missing = True
         self.history = {}
 
         self.streamer_url = f"https://www.twitch.tv/{self.username}"
@@ -36,14 +41,27 @@ class Streamer:
         )
 
     def set_offline(self):
-        self.offline_at = time.time()
-        self.is_online = False
+        if self.is_online is True:
+            self.offline_at = time.time()
+            self.is_online = False
+
         logger.info(f"{self} is Offline!", extra={"emoji": ":sleeping:"})
 
     def set_online(self):
-        self.online_at = time.time()
-        self.is_online = True
+        if self.is_online is False:
+            self.online_at = time.time()
+            self.is_online = True
+            # Watch streak variables
+            self.watch_streak_missing = True
+            self.minute_watched = 0
+            self.last_minute_watched = 0
+
         logger.info(f"{self} is Online!", extra={"emoji": ":partying_face:"})
+
+    def update_minute_watched(self):
+        if self.last_minute_watched != 0:
+            self.minute_watched += round((time.time() - self.last_minute_watched) / 60, 5)
+        self.last_minute_watched = time.time()
 
     def print_history(self):
         return ", ".join(
@@ -58,6 +76,9 @@ class Streamer:
             self.history[reason_code] = {"counter": 0, "amount": 0}
         self.history[reason_code]["counter"] += 1
         self.history[reason_code]["amount"] += earned
+
+        if reason_code == "WATCH_STREAK":
+            self.watch_streak_missing = False
 
     def set_less_printing(self, value):
         self.less_printing = value

--- a/TwitchChannelPointsMiner/classes/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/Streamer.py
@@ -60,7 +60,9 @@ class Streamer:
 
     def update_minute_watched(self):
         if self.last_minute_watched != 0:
-            self.minute_watched += round((time.time() - self.last_minute_watched) / 60, 5)
+            self.minute_watched += round(
+                (time.time() - self.last_minute_watched) / 60, 5
+            )
         self.last_minute_watched = time.time()
 
     def print_history(self):

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -124,7 +124,9 @@ class Twitch:
 
     def claim_bonus(self, streamer, claim_id, less_printing=False):
         if less_printing is False:
-            logger.info(f"Claiming the bonus for {streamer}!", extra={"emoji": ":gift:"})
+            logger.info(
+                f"Claiming the bonus for {streamer}!", extra={"emoji": ":gift:"}
+            )
 
         json_data = {
             "operationName": "ClaimCommunityPoints",
@@ -161,7 +163,11 @@ class Twitch:
         streamer.channel_points = community_points["balance"]
         # logger.info(f"{streamer.channel_points} channel points for {streamer.username}!")
         if community_points["availableClaim"] is not None:
-            self.claim_bonus(streamer, community_points["availableClaim"]["id"], less_printing=less_printing)
+            self.claim_bonus(
+                streamer,
+                community_points["availableClaim"]["id"],
+                less_printing=less_printing,
+            )
 
     def make_predictions(self, event):
         decision = event.bet.calculate(event.streamer.channel_points)

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -198,12 +198,12 @@ class Twitch:
             if watch_streak is True:
                 for index in streamers_index:
                     if (
-                        streamers[index].watch_streak_missing
+                        streamers[index].watch_streak_missing is True
                         and (
                             streamers[index].offline_at == 0
                             or ((time.time() - streamers[index].offline_at) // 60) > 30
                         )
-                        and streamers[index].minute_watched <= 6
+                        and streamers[index].minute_watched <= random.uniform(16, 18)
                     ):
                         logger.info(
                             f"Switch priority: {streamers[index]}, WatchStreak missing is {streamers[index].watch_streak_missing} and minute_watched: {streamers[index].minute_watched}"

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -209,7 +209,7 @@ class Twitch:
                             streamers[index].offline_at == 0
                             or ((time.time() - streamers[index].offline_at) // 60) > 30
                         )
-                        and streamers[index].minute_watched <= 6
+                        and streamers[index].minute_watched < 7
                     ):
                         logger.info(
                             f"Switch priority: {streamers[index]}, WatchStreak missing is {streamers[index].watch_streak_missing} and minute_watched: {streamers[index].minute_watched}"

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -197,6 +197,8 @@ class Twitch:
             Check if we need need to change priority based on watch streak
             Viewers receive points for returning for x consecutive streams.
             Each stream must be at least 10 minutes long and it must have been at least 30 minutes since the last stream ended.
+
+            Watch at least 6m for get the +10
             """
             streamers_watching = []
             if watch_streak is True:
@@ -207,7 +209,7 @@ class Twitch:
                             streamers[index].offline_at == 0
                             or ((time.time() - streamers[index].offline_at) // 60) > 30
                         )
-                        and streamers[index].minute_watched <= random.uniform(1, 2)
+                        and streamers[index].minute_watched <= 6
                     ):
                         logger.info(
                             f"Switch priority: {streamers[index]}, WatchStreak missing is {streamers[index].watch_streak_missing} and minute_watched: {streamers[index].minute_watched}"

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -21,9 +21,7 @@ from TwitchChannelPointsMiner.classes.Exceptions import (
     StreamerIsOfflineException,
     StreamerDoesNotExistException,
 )
-
-TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko"
-USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36"
+from TwitchChannelPointsMiner.constants import TWITCH_CLIENT_ID, USER_AGENT, TWITCH_API, TWITCH_GQL
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +74,7 @@ class Twitch:
 
     def post_gql_request(self, json_data):
         response = requests.post(
-            "https://gql.twitch.tv/gql",
+            TWITCH_GQL,
             json=json_data,
             headers={
                 "Authorization": f"OAuth {self.twitch_login.get_auth_token()}",
@@ -211,8 +209,8 @@ class Twitch:
                         )
                         and streamers[index].minute_watched < 7
                     ):
-                        logger.info(
-                            f"Switch priority: {streamers[index]}, WatchStreak missing is {streamers[index].watch_streak_missing} and minute_watched: {streamers[index].minute_watched}"
+                        logger.debug(
+                            f"Switch priority: {streamers[index]}, WatchStreak missing is {streamers[index].watch_streak_missing} and minute_watched: {round(streamers[index].minute_watched, 2)}"
                         )
                         streamers_watching.append(index)
                         if len(streamers_watching) == 2:
@@ -287,7 +285,7 @@ class Twitch:
         return followers
 
     def __do_helix_request(self, query, response_as_json=True):
-        url = f"https://api.twitch.tv/helix/{query.strip('/')}"
+        url = f"{TWITCH_API}/helix/{query.strip('/')}"
         response = self.twitch_login.session.get(url)
         logger.debug(
             f"Query: {query}, Status code: {response.status_code}, Content: {response.json()}"

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -21,7 +21,12 @@ from TwitchChannelPointsMiner.classes.Exceptions import (
     StreamerIsOfflineException,
     StreamerDoesNotExistException,
 )
-from TwitchChannelPointsMiner.constants import TWITCH_CLIENT_ID, USER_AGENT, TWITCH_API, TWITCH_GQL
+from TwitchChannelPointsMiner.constants import (
+    TWITCH_CLIENT_ID,
+    USER_AGENT,
+    TWITCH_API,
+    TWITCH_GQL,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -207,7 +207,7 @@ class Twitch:
                             streamers[index].offline_at == 0
                             or ((time.time() - streamers[index].offline_at) // 60) > 30
                         )
-                        and streamers[index].minute_watched <= random.uniform(16, 18)
+                        and streamers[index].minute_watched <= random.uniform(1, 2)
                     ):
                         logger.info(
                             f"Switch priority: {streamers[index]}, WatchStreak missing is {streamers[index].watch_streak_missing} and minute_watched: {streamers[index].minute_watched}"

--- a/TwitchChannelPointsMiner/classes/TwitchBrowser.py
+++ b/TwitchChannelPointsMiner/classes/TwitchBrowser.py
@@ -17,65 +17,24 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.common.exceptions import TimeoutException, JavascriptException
 
 from TwitchChannelPointsMiner.classes.EventPrediction import EventPrediction
-
-TWITCH_URL = "https://www.twitch.tv/"
-
-# XPath Selector and Javascript helpers
-cookiePolicyQuery = 'button[data-a-target="consent-banner-accept"]'
-
-streamCoinsMenuXP = '//div[@data-test-selector="community-points-summary"]//button'
-streamCoinsMenuJS = 'document.querySelector("[data-test-selector=\'community-points-summary\']").getElementsByTagName("button")[0].click();'
-
-streamBetTitleInBet = '[data-test-selector="predictions-list-item__title"]'
-
-streamBetCustomVoteXP = (
-    "button[data-test-selector='prediction-checkout-active-footer__input-type-toggle']"
+from TwitchChannelPointsMiner.constants import (
+    TWITCH_URL,
+    cookiePolicyQuery,
+    streamCoinsMenuXP,
+    streamCoinsMenuJS,
+    streamBetTitleInBet,
+    streamBetCustomVoteXP,
+    streamBetCustomVoteJS,
+    streamBetMainDiv,
+    streamBetVoteInputXP,
+    streamBetVoteButtonXP,
+    streamBetVoteInputJS,
+    streamBetVoteButtonJS,
+    localStorageJS,
+    clearStyleChatJS,
+    maximizeBetWindowJS,
+    scrollDownBetWindowJS,
 )
-streamBetCustomVoteJS = f'document.querySelector("{streamBetCustomVoteXP}").click();'
-
-streamBetMainDiv = "//div[@id='channel-points-reward-center-body']//div[contains(@class,'custom-prediction-button')]"
-streamBetVoteInputXP = f"({streamBetMainDiv}//input)"
-streamBetVoteButtonXP = f"({streamBetMainDiv}//button)"
-
-streamBetVoteInputJS = 'document.getElementById("channel-points-reward-center-body").getElementsByTagName("input")[{}].value = {};'
-streamBetVoteButtonJS = 'document.getElementById("channel-points-reward-center-body").getElementsByTagName("button")[{}].click();'
-
-# Some Javascript code that should help the script
-localStorageJS = """
-window.localStorage.setItem("volume", 0);
-window.localStorage.setItem("channelPointsOnboardingDismissed", true);
-window.localStorage.setItem("twilight.theme", 1);
-window.localStorage.setItem("mature", true);
-window.localStorage.setItem("rebrand-notice-dismissed", true);
-window.localStorage.setItem("emoteAnimationsEnabled", false);
-window.localStorage.setItem("chatPauseSetting", "ALTKEY");
-"""
-clearStyleChatJS = """
-var item = document.querySelector('[data-test-selector="chat-scrollable-area__message-container"]');
-if (item) {
-    var parent = item.closest("div.simplebar-scroll-content");
-    if(parent) parent.hidden = true;
-}
-var header = document.querySelector('[data-test-selector="channel-leaderboard-container"]');
-if(header) header.hidden = true;
-"""
-maximizeBetWindowJS = """
-var absolute = document.querySelector('[aria-describedby="channel-points-reward-center-body"]').closest("div.tw-absolute")
-if(absolute) absolute.classList.remove("tw-absolute")
-
-document.getElementsByClassName("reward-center__content")[0].style.width = "44rem";
-document.getElementsByClassName("reward-center__content")[0].style.height = "55rem";
-
-document.querySelector('[aria-describedby="channel-points-reward-center-body"]').style["max-height"] = "55rem";
-
-document.getElementsByClassName("reward-center-body")[0].style["max-width"] = "44rem";
-// document.getElementsByClassName("reward-center-body")[0].style["min-height"] = "55rem";
-"""
-scrollDownBetWindowJS = """
-var scrollable = document.getElementById("channel-points-reward-center-body").closest("div.simplebar-scroll-content");
-scrollable.scrollTop = scrollable.scrollHeight;
-"""
-
 
 logger = logging.getLogger(__name__)
 

--- a/TwitchChannelPointsMiner/classes/TwitchBrowser.py
+++ b/TwitchChannelPointsMiner/classes/TwitchBrowser.py
@@ -4,7 +4,6 @@ import random
 import os
 import platform
 
-from millify import millify
 from pathlib import Path
 from datetime import datetime
 from enum import Enum, auto

--- a/TwitchChannelPointsMiner/classes/TwitchBrowser.py
+++ b/TwitchChannelPointsMiner/classes/TwitchBrowser.py
@@ -334,6 +334,9 @@ class TwitchBrowser:
                 )
                 self.browser.get(event.streamer.chat_url)
                 time.sleep(random.uniform(3, 5))
+                self.__click_when_exist(
+                    cookiePolicyQuery, By.CSS_SELECTOR, suppress_error=True, timeout=1.5
+                )
 
                 # Hide the chat ... Don't ask me why
                 self.__execute_script(clearStyleChatJS, suppress_error=True)
@@ -343,8 +346,6 @@ class TwitchBrowser:
                 logger.error(
                     f"Attempt {attempt+1} failed!", extra={"emoji": ":wrench:"}
                 )
-                # Maybe we have failed because we have Cookies also in chat - Low probability
-                self.__click_when_exist(cookiePolicyQuery, By.CSS_SELECTOR, suppress_error=True, timeout=2.5)
         return False, time.time() - start_time
 
     def __bet_chains_methods(self, event):

--- a/TwitchChannelPointsMiner/classes/TwitchBrowser.py
+++ b/TwitchChannelPointsMiner/classes/TwitchBrowser.py
@@ -460,7 +460,8 @@ class TwitchBrowser:
                 )
         else:
             logger.info(
-                f"Oh no! The event It's not more ACTIVE, current status: {event.status}", extra={"emoji": ":disappointed_relieved:"}
+                f"Oh no! The event It's not more ACTIVE, current status: {event.status}",
+                extra={"emoji": ":disappointed_relieved:"},
             )
 
         self.browser.get("about:blank")

--- a/TwitchChannelPointsMiner/classes/TwitchBrowser.py
+++ b/TwitchChannelPointsMiner/classes/TwitchBrowser.py
@@ -409,7 +409,6 @@ class TwitchBrowser:
                                     extra={"emoji": ":wrench:"},
                                 )
                                 if self.__click_on_vote(event, selector_index) is True:
-                                    self.__debug(event, "click_on_vote")
                                     event.bet_placed = True
                                     time.sleep(random.uniform(5, 10))
                         except Exception:

--- a/TwitchChannelPointsMiner/classes/TwitchBrowser.py
+++ b/TwitchChannelPointsMiner/classes/TwitchBrowser.py
@@ -286,10 +286,11 @@ class TwitchBrowser:
             )
 
     def __click_when_exist(
-        self, selector, by: By = By.CSS_SELECTOR, suppress_error=False
+        self, selector, by: By = By.CSS_SELECTOR, suppress_error=False, timeout=None
     ):
+        timeout = self.settings.timeout if timeout is None else timeout
         try:
-            element = WebDriverWait(self.browser, self.settings.timeout).until(
+            element = WebDriverWait(self.browser, timeout).until(
                 expected_conditions.element_to_be_clickable((by, selector))
             )
             ActionChains(self.browser).move_to_element(element).click().perform()
@@ -342,6 +343,8 @@ class TwitchBrowser:
                 logger.error(
                     f"Attempt {attempt+1} failed!", extra={"emoji": ":wrench:"}
                 )
+                # Maybe we have failed because we have Cookies also in chat - Low probability
+                self.__click_when_exist(cookiePolicyQuery, By.CSS_SELECTOR, suppress_error=True, timeout=2.5)
         return False, time.time() - start_time
 
     def __bet_chains_methods(self, event):

--- a/TwitchChannelPointsMiner/classes/TwitchBrowser.py
+++ b/TwitchChannelPointsMiner/classes/TwitchBrowser.py
@@ -460,7 +460,7 @@ class TwitchBrowser:
                 )
         else:
             logger.info(
-                f"Oh no! The event it's not more ACTIVE, current status: {event.status}"
+                f"Oh no! The event It's not more ACTIVE, current status: {event.status}", extra={"emoji": ":disappointed_relieved:"}
             )
 
         self.browser.get("about:blank")

--- a/TwitchChannelPointsMiner/classes/TwitchLogin.py
+++ b/TwitchChannelPointsMiner/classes/TwitchLogin.py
@@ -20,10 +20,9 @@ class TwitchLogin:
         self.token = None
         self.login_check_result = False
         self.session = requests.session()
-        self.session.headers.update({
-            "Client-ID": self.client_id,
-            "User-Agent": user_agent
-        })
+        self.session.headers.update(
+            {"Client-ID": self.client_id, "User-Agent": user_agent}
+        )
         self.username = username
         self.user_id = None
         self.email = None

--- a/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
+++ b/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
@@ -59,7 +59,7 @@ class TwitchWebSocket(WebSocketApp):
         self.less_printing = parent_pool.less_printing
 
         self.last_message_time = 0
-        self.last_message_type = None
+        self.last_message_type_topic = None
 
         self.last_pong = time.time()
         self.last_ping = time.time()

--- a/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
+++ b/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
@@ -2,25 +2,12 @@ import json
 import logging
 import time
 
-from random import randrange
 from websocket import WebSocketApp
 
+from TwitchChannelPointsMiner.utils import create_nonce
+
+
 logger = logging.getLogger(__name__)
-
-
-# https://en.wikipedia.org/wiki/Cryptographic_nonce
-def create_nonce(length=30):
-    nonce = ""
-    for i in range(length):
-        char_index = randrange(0, 10 + 26 + 26)
-        if char_index < 10:
-            char = chr(ord("0") + char_index)
-        elif char_index < 10 + 26:
-            char = chr(ord("a") + char_index - 10)
-        else:
-            char = chr(ord("A") + char_index - 26 - 10)
-        nonce += char
-    return nonce
 
 
 class TwitchWebSocket(WebSocketApp):

--- a/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
+++ b/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
@@ -58,8 +58,8 @@ class TwitchWebSocket(WebSocketApp):
         self.events_predictions = parent_pool.events_predictions
         self.less_printing = parent_pool.less_printing
 
-        self.last_message_time = 0
-        self.last_message_type_topic = None
+        self.last_message_timestamp = None
+        self.last_message_type_channel = None
 
         self.last_pong = time.time()
         self.last_ping = time.time()

--- a/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
+++ b/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
@@ -2,7 +2,6 @@ import json
 import logging
 import time
 
-from datetime import timedelta
 from random import randrange
 from websocket import WebSocketApp
 
@@ -66,7 +65,7 @@ class TwitchWebSocket(WebSocketApp):
         self.last_ping = time.time()
 
     def elapsed_last_pong(self):
-        return (time.time - self.last_pong) // 60
+        return (time.time() - self.last_pong) // 60
 
     def elapsed_last_ping(self):
-        return (time.time - self.last_ping) // 60
+        return (time.time() - self.last_ping) // 60

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -122,9 +122,10 @@ class WebSocketsPool:
 
             message = json.loads(data["message"])
             message_type = message["type"]
-            message_timestamp = message["timestamp"]
 
             message_data = message["data"] if "data" in message else None
+            message_timestamp = None if message_data is None else message_data["timestamp"]
+
             channel_id = (
                 None
                 if message_data is None

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -174,6 +174,8 @@ class WebSocketsPool:
                         event_id = event_dict["id"]
                         event_status = event_dict["status"]
 
+                        current_timestamp = parser.parse(message.timestamp)
+
                         if event_id not in ws.events_predictions:
                             if event_status == "ACTIVE":
                                 prediction_window_seconds = float(
@@ -195,7 +197,7 @@ class WebSocketsPool:
                                 )
                                 if (
                                     ws.streamers[streamer_index].is_online
-                                    and event.closing_bet_after(message.timestamp) > 0
+                                    and event.closing_bet_after(current_timestamp) > 0
                                 ):
                                     ws.events_predictions[event_id] = event
                                     if ws.twitch_browser.currently_is_betting is False:
@@ -209,7 +211,7 @@ class WebSocketsPool:
                                             # place_bet_thread = threading.Timer(event.closing_bet_after(current_timestamp), ws.twitch.make_predictions, (ws.events_predictions[event_id],))
                                             start_after = (
                                                 event.closing_bet_after(
-                                                    message.timestamp
+                                                    current_timestamp
                                                 )
                                                 - execution_time
                                             )

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -122,6 +122,7 @@ class WebSocketsPool:
 
             message = json.loads(data["message"])
             message_type = message["type"]
+            message_timestamp = message["timestamp"]
 
             message_data = message["data"] if "data" in message else None
             channel_id = (
@@ -145,14 +146,13 @@ class WebSocketsPool:
             # If we have more than one PubSub connection, messages may be duplicated
             # Check the concatenation between message_type and channel_id
             if (
-                time.time() - ws.last_message_time < 0.1
-                and ws.last_message_type_topic == f"{message_type}.{channel_id}"
+                ws.last_message_timestamp == message_timestamp
+                and ws.last_message_type_channel == f"{message_type}.{channel_id}"
             ):
-                ws.last_message_time = time.time()
                 return
 
-            ws.last_message_time = time.time()
-            ws.last_message_type_topic = f"{message_type}.{channel_id}"
+            ws.last_message_timestamp = message_timestamp
+            ws.last_message_type_channel = f"{message_type}.{channel_id}"
 
             streamer_index = get_streamer_index(ws.streamers, channel_id)
             if streamer_index != -1:

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -182,7 +182,7 @@ class WebSocketsPool:
                                     event_dict["prediction_window_seconds"]
                                 )
                                 prediction_window_seconds -= (
-                                    25 if prediction_window_seconds <= 120 else 50
+                                    25 if prediction_window_seconds <= 180 else 60
                                 )
                                 event = EventPrediction(
                                     ws.streamers[streamer_index],

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -158,7 +158,7 @@ class WebSocketsPool:
                             if ws.streamers[streamer_index].is_online is True:
                                 ws.streamers[streamer_index].set_offline()
                         elif message.type == "viewcount":
-                            if (ws.streamers[streamer_index].stream_up == 0 or ((time.time() - ws.streamers[streamer_index].stream_up) > 10)):
+                            if (ws.streamers[streamer_index].stream_up == 0 or ((time.time() - ws.streamers[streamer_index].stream_up) > 30)):
                                 ws.twitch.check_streamer_online(
                                     ws.streamers[streamer_index]
                                 )

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -4,7 +4,7 @@ import time
 import json
 import random
 
-from datetime import fromtimestamp
+from datetime import datetime
 from dateutil import parser
 
 from TwitchChannelPointsMiner.classes.EventPrediction import EventPrediction
@@ -132,9 +132,9 @@ class WebSocketsPool:
                     message_data["timestamp"]
                     if "timestamp" in message_data
                     else (
-                        fromtimestamp(message_data["server_time"]).isoformat() + "Z"
+                        datetime.fromtimestamp(message_data["server_time"]).isoformat() + "Z"
                         if "server_time" in message_data
-                        else fromtimestamp(time.time()).isoformat() + "Z"
+                        else datetime.fromtimestamp(time.time()).isoformat() + "Z"
                     )
                 )
             )

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -132,7 +132,8 @@ class WebSocketsPool:
                     message_data["timestamp"]
                     if "timestamp" in message_data
                     else (
-                        datetime.fromtimestamp(message_data["server_time"]).isoformat() + "Z"
+                        datetime.fromtimestamp(message_data["server_time"]).isoformat()
+                        + "Z"
                         if "server_time" in message_data
                         else datetime.fromtimestamp(time.time()).isoformat() + "Z"
                     )
@@ -158,20 +159,23 @@ class WebSocketsPool:
             )
 
             # If we have more than one PubSub connection, messages may be duplicated
-            # Check the concatenation between message_type and channel_id
+            # Check the concatenation between message_type.top.channel_id
             if (
-                ws.last_message_type_channel != ws.last_message_timestamp
+                ws.last_message_type_channel is not None
+                and ws.last_message_timestamp is not None
                 and ws.last_message_timestamp == message_timestamp
-                and ws.last_message_type_channel == f"{message_type}.{channel_id}"
+                and ws.last_message_type_channel
+                == f"{message_type}.{topic}.{topic_user}.{channel_id}"
             ):
                 return
 
             ws.last_message_timestamp = message_timestamp
-            ws.last_message_type_channel = f"{message_type}.{channel_id}"
+            ws.last_message_type_channel = (
+                f"{message_type}.{topic}.{topic_user}.{channel_id}"
+            )
 
             streamer_index = get_streamer_index(ws.streamers, channel_id)
             if streamer_index != -1:
-
                 try:
                     if topic == "community-points-user-v1":
                         if message_type == "points-earned":

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -152,13 +152,16 @@ class WebSocketsPool:
 
                     elif message.topic == "video-playback-by-id":
                         # There is stream-up message type, but it's sent earlier than the API updates
-                        if message.type == "stream-down":
+                        if message.type == "stream-up":
+                            ws.streamers[streamer_index].stream_up = time.time()
+                        elif message.type == "stream-down":
                             if ws.streamers[streamer_index].is_online is True:
                                 ws.streamers[streamer_index].set_offline()
                         elif message.type == "viewcount":
-                            ws.twitch.check_streamer_online(
-                                ws.streamers[streamer_index]
-                            )
+                            if (ws.streamers[streamer_index].stream_up == 0 or ((time.time() - ws.streamers[streamer_index].stream_up) > 10)):
+                                ws.twitch.check_streamer_online(
+                                    ws.streamers[streamer_index]
+                                )
 
                     elif message.topic == "raid":
                         if message.type == "raid_update_v2":

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -167,15 +167,16 @@ class WebSocketsPool:
                             )
 
                 elif topic == "video-playback-by-id":
+                    # There is stream-up message type, but it's sent earlier than the API updates
                     streamer_index = get_streamer_index(ws.streamers, topic_user)
                     if streamer_index != -1:
                         if message_type == "stream-down":
-                            ws.streamers[streamer_index].set_offline()
+                            if ws.streamers[streamer_index].is_online is True:
+                                ws.streamers[streamer_index].set_offline()
                         elif message_type == "viewcount":
                             ws.twitch.check_streamer_online(
                                 ws.streamers[streamer_index]
                             )
-                        # There is stream-up message type, but it's sent earlier than the API updates
 
                 elif topic == "raid":
                     streamer_index = get_streamer_index(ws.streamers, topic_user)
@@ -234,7 +235,6 @@ class WebSocketsPool:
                                         )
                                         if start_bet_status is True:
                                             # place_bet_thread = threading.Timer(event.closing_bet_after(current_timestamp), ws.twitch.make_predictions, (ws.events_predictions[event_id],))
-                                            execution_time = round(execution_time, 2)
                                             start_after = (
                                                 event.closing_bet_after(
                                                     current_timestamp
@@ -242,6 +242,7 @@ class WebSocketsPool:
                                                 - execution_time
                                             )
                                             start_after = max(1, start_after)
+                                            start_after = round(start_after, 2)
                                             place_bet_thread = threading.Timer(
                                                 start_after,
                                                 ws.twitch_browser.place_bet,

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -147,7 +147,7 @@ class WebSocketsPool:
                             ws.twitch.claim_bonus(
                                 ws.streamers[streamer_index],
                                 message.data["claim"]["id"],
-                                less_printing=ws.less_printing
+                                less_printing=ws.less_printing,
                             )
 
                     elif message.topic == "video-playback-by-id":
@@ -158,7 +158,7 @@ class WebSocketsPool:
                             if ws.streamers[streamer_index].is_online is True:
                                 ws.streamers[streamer_index].set_offline()
                         elif message.type == "viewcount":
-                            if (ws.streamers[streamer_index].stream_up == 0 or ((time.time() - ws.streamers[streamer_index].stream_up) > 30)):
+                            if ws.streamers[streamer_index].stream_up_elapsed():
                                 ws.twitch.check_streamer_online(
                                     ws.streamers[streamer_index]
                                 )

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -161,7 +161,7 @@ class WebSocketsPool:
                     elif message.topic == "raid":
                         if message.type == "raid_update_v2":
                             raid = Raid(
-                                message["raid"]["id"], message["raid"]["target_login"]
+                                message.message["raid"]["id"], message.message["raid"]["target_login"]
                             )
                             ws.twitch.update_raid(ws.streamers[streamer_index], raid)
 

--- a/TwitchChannelPointsMiner/constants.py
+++ b/TwitchChannelPointsMiner/constants.py
@@ -1,0 +1,64 @@
+# Twitch endpoints
+TWITCH_URL = "https://www.twitch.tv"
+TWITCH_API = "https://api.twitch.tv"
+TWITCH_GQL = "https://gql.twitch.tv/gql"
+TWITCH_WEBSOCKET = "wss://pubsub-edge.twitch.tv/v1"
+TWITCH_CLIENT_ID = "kimne78kx3ncx6brgo4mv6wki5h1ko"
+
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36"
+
+# XPath Selector and Javascript helpers
+cookiePolicyQuery = 'button[data-a-target="consent-banner-accept"]'
+
+streamCoinsMenuXP = '//div[@data-test-selector="community-points-summary"]//button'
+streamCoinsMenuJS = 'document.querySelector("[data-test-selector=\'community-points-summary\']").getElementsByTagName("button")[0].click();'
+
+streamBetTitleInBet = '[data-test-selector="predictions-list-item__title"]'
+
+streamBetCustomVoteXP = (
+    "button[data-test-selector='prediction-checkout-active-footer__input-type-toggle']"
+)
+streamBetCustomVoteJS = f'document.querySelector("{streamBetCustomVoteXP}").click();'
+
+streamBetMainDiv = "//div[@id='channel-points-reward-center-body']//div[contains(@class,'custom-prediction-button')]"
+streamBetVoteInputXP = f"({streamBetMainDiv}//input)"
+streamBetVoteButtonXP = f"({streamBetMainDiv}//button)"
+
+streamBetVoteInputJS = 'document.getElementById("channel-points-reward-center-body").getElementsByTagName("input")[{}].value = {};'
+streamBetVoteButtonJS = 'document.getElementById("channel-points-reward-center-body").getElementsByTagName("button")[{}].click();'
+
+# Some Javascript code that should help the script
+localStorageJS = """
+window.localStorage.setItem("volume", 0);
+window.localStorage.setItem("channelPointsOnboardingDismissed", true);
+window.localStorage.setItem("twilight.theme", 1);
+window.localStorage.setItem("mature", true);
+window.localStorage.setItem("rebrand-notice-dismissed", true);
+window.localStorage.setItem("emoteAnimationsEnabled", false);
+window.localStorage.setItem("chatPauseSetting", "ALTKEY");
+"""
+clearStyleChatJS = """
+var item = document.querySelector('[data-test-selector="chat-scrollable-area__message-container"]');
+if (item) {
+    var parent = item.closest("div.simplebar-scroll-content");
+    if(parent) parent.hidden = true;
+}
+var header = document.querySelector('[data-test-selector="channel-leaderboard-container"]');
+if(header) header.hidden = true;
+"""
+maximizeBetWindowJS = """
+var absolute = document.querySelector('[aria-describedby="channel-points-reward-center-body"]').closest("div.tw-absolute")
+if(absolute) absolute.classList.remove("tw-absolute")
+
+document.getElementsByClassName("reward-center__content")[0].style.width = "44rem";
+document.getElementsByClassName("reward-center__content")[0].style.height = "55rem";
+
+document.querySelector('[aria-describedby="channel-points-reward-center-body"]').style["max-height"] = "55rem";
+
+document.getElementsByClassName("reward-center-body")[0].style["max-width"] = "44rem";
+// document.getElementsByClassName("reward-center-body")[0].style["min-height"] = "55rem";
+"""
+scrollDownBetWindowJS = """
+var scrollable = document.getElementById("channel-points-reward-center-body").closest("div.simplebar-scroll-content");
+scrollable.scrollTop = scrollable.scrollHeight;
+"""

--- a/TwitchChannelPointsMiner/utils.py
+++ b/TwitchChannelPointsMiner/utils.py
@@ -1,0 +1,74 @@
+import time
+
+from datetime import datetime, timezone
+from random import randrange
+
+
+def get_streamer_index(streamers, channel_id):
+    try:
+        return next(
+            i for i, x in enumerate(streamers) if str(x.channel_id) == str(channel_id)
+        )
+    except StopIteration:
+        return -1
+
+
+def server_time(message_data):
+    return (
+        datetime.fromtimestamp(message_data["server_time"], timezone.utc).isoformat() + "Z"
+        if message_data is not None and "server_time" in message_data
+        else datetime.fromtimestamp(time.time(), timezone.utc).isoformat() + "Z"
+    )
+
+
+def get_timestamp(message):
+    message_data = message["data"] if "data" in message else None
+    return (
+        server_time(message)
+        if message_data is None
+        else (
+            message_data["timestamp"]
+            if "timestamp" in message_data
+            else server_time(message_data)
+        )
+    )
+
+
+def get_channel_id(message, topic_user):
+    message_data = message["data"] if "data" in message else None
+    return (
+        topic_user
+        if message_data is None
+        else (
+            message_data["prediction"]["channel_id"]
+            if "prediction" in message_data
+            else (
+                message_data["claim"]["channel_id"]
+                if "claim" in message_data
+                else (
+                    message_data["channel_id"]
+                    if "channel_id" in message_data
+                    else topic_user
+                )
+            )
+        )
+    )
+
+
+def float_round(value):
+    return round(float(value), 2)
+
+
+# https://en.wikipedia.org/wiki/Cryptographic_nonce
+def create_nonce(length=30):
+    nonce = ""
+    for i in range(length):
+        char_index = randrange(0, 10 + 26 + 26)
+        if char_index < 10:
+            char = chr(ord("0") + char_index)
+        elif char_index < 10 + 26:
+            char = chr(ord("a") + char_index - 10)
+        else:
+            char = chr(ord("A") + char_index - 26 - 10)
+        nonce += char
+    return nonce

--- a/TwitchChannelPointsMiner/utils.py
+++ b/TwitchChannelPointsMiner/utils.py
@@ -13,50 +13,17 @@ def get_streamer_index(streamers, channel_id):
         return -1
 
 
+def float_round(value):
+    return round(float(value), 2)
+
+
 def server_time(message_data):
     return (
-        datetime.fromtimestamp(message_data["server_time"], timezone.utc).isoformat() + "Z"
+        datetime.fromtimestamp(message_data["server_time"], timezone.utc).isoformat()
+        + "Z"
         if message_data is not None and "server_time" in message_data
         else datetime.fromtimestamp(time.time(), timezone.utc).isoformat() + "Z"
     )
-
-
-def get_timestamp(message):
-    message_data = message["data"] if "data" in message else None
-    return (
-        server_time(message)
-        if message_data is None
-        else (
-            message_data["timestamp"]
-            if "timestamp" in message_data
-            else server_time(message_data)
-        )
-    )
-
-
-def get_channel_id(message, topic_user):
-    message_data = message["data"] if "data" in message else None
-    return (
-        topic_user
-        if message_data is None
-        else (
-            message_data["prediction"]["channel_id"]
-            if "prediction" in message_data
-            else (
-                message_data["claim"]["channel_id"]
-                if "claim" in message_data
-                else (
-                    message_data["channel_id"]
-                    if "channel_id" in message_data
-                    else topic_user
-                )
-            )
-        )
-    )
-
-
-def float_round(value):
-    return round(float(value), 2)
 
 
 # https://en.wikipedia.org/wiki/Cryptographic_nonce

--- a/TwitchChannelPointsMiner/utils.py
+++ b/TwitchChannelPointsMiner/utils.py
@@ -13,8 +13,8 @@ def get_streamer_index(streamers, channel_id):
         return -1
 
 
-def float_round(value):
-    return round(float(value), 2)
+def float_round(number, ndigits=2):
+    return round(float(number), ndigits)
 
 
 def server_time(message_data):
@@ -24,6 +24,10 @@ def server_time(message_data):
         if message_data is not None and "server_time" in message_data
         else datetime.fromtimestamp(time.time(), timezone.utc).isoformat() + "Z"
     )
+
+
+def calculate_start_after(closing_bet_after, execution_time):
+    return round(max(1, closing_bet_after - execution_time), 2)
 
 
 # https://en.wikipedia.org/wiki/Cryptographic_nonce

--- a/example.py
+++ b/example.py
@@ -10,6 +10,7 @@ twitch_miner = TwitchChannelPointsMiner(
     username="your-twitch-username",
     make_predictions=True,              # If you want to Bet / Make prediction | The browser will never start
     follow_raid=True,                   # Follow raid to obtain more points
+    watch_streak=True,                  # If a streamer go online change the priotiry of streamers array and catch the watch screak. Issue #11
     logger_settings=LoggerSettings(
         save=True,                      # If you want to save logs in file (suggested)
         console_level=logging.INFO,     # Level of logs - use logging.DEBUG for more info)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setuptools.setup(
     name="Twitch-Channel-Points-Miner-v2",
-    version="2.2.5",
+    version="2.3.1",
     author="Tkd-Alex (Alessandro Maggio)",
     author_email="alex.tkd.alex@gmail.com",
     description="A simple script that will watch a stream for you and earn the channel points.",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setuptools.setup(
     name="Twitch-Channel-Points-Miner-v2",
-    version="2.3.1",
+    version="2.3.5",
     author="Tkd-Alex (Alessandro Maggio)",
     author_email="alex.tkd.alex@gmail.com",
     description="A simple script that will watch a stream for you and earn the channel points.",


### PR DESCRIPTION
- [x] **Better 'Watch Streak' strategy in priority system**. We can close #11
- [x] Create a class for manage TwitchMessage https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/commit/16604e2c887d2ea549759166e2a321d4c2c4d77e
- [x] Create a single file with all constants https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/commit/6c587dcd81dc7dc37b68321f9e98655aa3c8d0b8
- [x] Other improvement and code refactoring
- [x] Manage the API delay update when user is online we continue to spam Offline https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/pull/16/commits/a89d6adb46473fe8c1f7221004473553cdc7ee08
- [x] Cookies after chat popup load https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/pull/16/commits/3e5b17bf3e5961585ed1bbf15bc3fbc977d680d7
