### PR TITLE
Do not change prediction in parent settings

### DIFF
--- a/TwitchChannelPointsMiner/utils.py
+++ b/TwitchChannelPointsMiner/utils.py
@@ -1,6 +1,7 @@
 import platform
 import re
 import time
+from copy import deepcopy
 from datetime import datetime, timezone
 from random import randrange
 
@@ -142,7 +143,7 @@ def copy_values_if_none(settings, defaults):
 def set_default_settings(settings, defaults):
     # If no settings was provided use the default settings ...
     if settings is None:
-        settings = defaults
+        settings = deepcopy(defaults)
     else:
         # If settings was provided but maybe are only partial set
         # Get the default values from Settings.streamer_settings


### PR DESCRIPTION
With the new settings changes introduced in #24 when you're a modorator of at least one channel, all your predictions are turned off if you used the default settings for a streamer.

This is due to this line keeping the same reference as the default settings instead of copying them:
https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/blob/4cd6a31a80258aff878fe83f15e51735ec0eee38/TwitchChannelPointsMiner/utils.py#L144-L145

Later when a mod status is detected, it then changes the parent settings thus turning predictions off for all streamers with the default settings:
https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/blob/4cd6a31a80258aff878fe83f15e51735ec0eee38/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py#L169-L170