### PR TITLE
Array of ws in WebSocketsPool.py

### DIFF
--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -248,14 +248,16 @@ class TwitchChannelPointsMiner:
             while self.running:
                 time.sleep(random.uniform(20, 60))
                 # Do an external control for WebSocket. Check if the thread is running
+                # Check if is not None because maybe we have already created a new connection on array+1 and now index is None
                 for index in range(0, len(self.ws_pool.ws)):
-                    if self.ws_pool.ws[index].elapsed_last_ping() > 5:
+                    if (
+                        self.ws_pool.ws[index] is not None
+                        and self.ws_pool.ws[index].elapsed_last_ping() > 10
+                    ):
                         logger.info(
-                            f"#{index} - The last ping was sent more than 5 minutes ago. Reconnecting to the WebSocket..."
+                            f"#{index} - The last PING was sent more than 10 minutes ago. Reconnecting to the WebSocket..."
                         )
-                        WebSocketsPool.handle_websocket_reconnection(
-                            self.ws_pool.ws[index]
-                        )
+                        WebSocketsPool.handle_reconnection(self.ws_pool.ws[index])
 
     def end(self, signum, frame):
         logger.info("CTRL+C Detected! Please wait just a moments!")

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -248,11 +248,14 @@ class TwitchChannelPointsMiner:
             while self.running:
                 time.sleep(random.uniform(20, 60))
                 # Do an external control for WebSocket. Check if the thread is running
-                if self.ws_pool.ws.elapsed_last_ping() > 5:
-                    logger.info(
-                        "The last ping was sent more than 5 minutes ago. Reconnecting to the WebSocket..."
-                    )
-                    WebSocketsPool.handle_websocket_reconnection(self.ws_pool.ws)
+                for index in range(0, len(self.ws_pool.ws)):
+                    if self.ws_pool.ws[index].elapsed_last_ping() > 5:
+                        logger.info(
+                            f"#{index} - The last ping was sent more than 5 minutes ago. Reconnecting to the WebSocket..."
+                        )
+                        WebSocketsPool.handle_websocket_reconnection(
+                            self.ws_pool.ws[index]
+                        )
 
     def end(self, signum, frame):
         logger.info("CTRL+C Detected! Please wait just a moments!")

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -94,7 +94,7 @@ class Twitch:
             },
         )
         logger.debug(
-            f"Data: {json_data}, Status code: {response.status_code}, Content: {response.json()}"
+            f"Data: {json_data}, Status code: {response.status_code}, Content: {response.text}"
         )
         return response.json()
 

--- a/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
+++ b/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
@@ -10,6 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 class TwitchWebSocket(WebSocketApp):
+    def __init__(self, index, *args, **kw):
+        super().__init__(*args, **kw)
+        self.index = index
+
     def listen(self, topic, auth_token=None):
         data = {"topics": [str(topic)]}
         if topic.is_user_topic() and auth_token is not None:
@@ -24,7 +28,7 @@ class TwitchWebSocket(WebSocketApp):
 
     def send(self, request):
         request_str = json.dumps(request, separators=(",", ":"))
-        logger.debug(f"Send: {request_str}")
+        logger.debug(f"#{self.index} - Send: {request_str}")
         super().send(request_str)
 
     def reset(self, parent_pool):

--- a/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
+++ b/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
@@ -33,7 +33,6 @@ class TwitchWebSocket(WebSocketApp):
 
     def reset(self, parent_pool):
         self.parent_pool = parent_pool
-        self.keep_running = True
         self.is_closed = False
         self.is_opened = False
         self.is_reconneting = False

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -43,7 +43,7 @@ class WebSocketsPool:
 
         self.ws[len(self.ws) - 1].topics.append(topic)
 
-        if not self.ws[len(self.ws) - 1].is_opened:
+        if self.ws[len(self.ws) - 1].is_opened is False:
             self.ws[len(self.ws) - 1].pending_topics.append(topic)
         else:
             self.ws[len(self.ws) - 1].listen(

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -38,17 +38,15 @@ class WebSocketsPool:
     """
 
     def submit(self, topic):
-        if self.ws == [] or len(self.ws[len(self.ws) - 1].topics) >= 50:
+        if self.ws == [] or len(self.ws[-1].topics) >= 50:
             self.append_new_websocket()
 
-        self.ws[len(self.ws) - 1].topics.append(topic)
+        self.ws[-1].topics.append(topic)
 
-        if self.ws[len(self.ws) - 1].is_opened is False:
-            self.ws[len(self.ws) - 1].pending_topics.append(topic)
+        if self.ws[-1].is_opened is False:
+            self.ws[-1].pending_topics.append(topic)
         else:
-            self.ws[len(self.ws) - 1].listen(
-                topic, self.twitch.twitch_login.get_auth_token()
-            )
+            self.ws[-1].listen(topic, self.twitch.twitch_login.get_auth_token())
 
     def append_new_websocket(self):
         self.ws.append(
@@ -60,11 +58,9 @@ class WebSocketsPool:
                 on_close=WebSocketsPool.handle_websocket_reconnection,
             )
         )
-        self.ws[len(self.ws) - 1].reset(self)
+        self.ws[-1].reset(self)
 
-        self.thread_ws = threading.Thread(
-            target=lambda: self.ws[len(self.ws) - 1].run_forever()
-        )
+        self.thread_ws = threading.Thread(target=lambda: self.ws[-1].run_forever())
         self.thread_ws.daemon = True
         self.thread_ws.start()
 

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -38,7 +38,7 @@ class WebSocketsPool:
     """
 
     def submit(self, topic):
-        if self.ws == [] or len(self.ws[-1].topics) >= 50:
+        if self.ws == [] or self.ws[-1] is None or len(self.ws[-1].topics) >= 50:
             self.append_new_websocket()
 
         self.ws[-1].topics.append(topic)


### PR DESCRIPTION
- Close #39
- Close #42

Create an array of ws instead of handle the last ws created.
Now the reconnection method It's fully working and we ws will be pushed into array.

```
05/02/21 07:16:00 - ERROR - [on_error]: #4 - WebSocket error: Connection is already closed.
05/02/21 07:16:00 - INFO - [on_close]: #4 - WebSocket closed
05/02/21 07:16:00 - INFO - [handle_reconnection]: #4 - Reconnecting to Twitch PubSub server in 30 seconds
```
```
05/02/21 07:40:00 - ERROR - [on_error]: #2 - WebSocket error: Connection is already closed.
05/02/21 07:40:00 - INFO - [on_close]: #2 - WebSocket closed
05/02/21 07:40:00 - INFO - [handle_reconnection]: #2 - Reconnecting to Twitch PubSub server in 30 seconds
```
```
05/02/21 11:09:00 - ERROR - [on_error]: #0 - WebSocket error: Connection is already closed.
05/02/21 11:09:00 - INFO - [on_close]: #0 - WebSocket closed
05/02/21 11:09:00 - INFO - [handle_reconnection]: #0 - Reconnecting to Twitch PubSub server in 30 seconds
```
```
05/02/21 04:15:36 - INFO - [run]: #1 - The last PONG was received more than 10 minutes ago. Reconnect the WebSocket
05/02/21 04:15:36 - INFO - [handle_reconnection]: #1 - Reconnecting to Twitch PubSub server in 30 seconds
```
```

```

The failed ws with index `#4, #2, #0, #1` was replaced with `#5, #6, #7`
```
05/02/21 13:00:57 - INFO - [end]: CTRL+C Detected! Please wait just a moments!

05/02/21 13:00:57 - INFO - [on_close]: #3 - WebSocket closed
05/02/21 13:00:57 - INFO - [on_close]: #5 - WebSocket closed
05/02/21 13:00:58 - INFO - [on_close]: #6 - WebSocket closed
05/02/21 13:00:58 - INFO - [on_close]: #7 - WebSocket closed
```

Tested **48hrs** without any relevant error.
Maybe in the future we could reduce the logs.