### PR TITLE
SyntaxError following readme example for ColorPalette

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,17 +311,17 @@ The script was developed to handle all the human error, lower-case upper case an
 ```python
 from colorama import Fore
 ColorPalette(
-    "STREAMER_ONLINE" = Fore.GREEN,
-    "STREAMER_OFFLINE" = Fore.RED,
-    "GAIN_FOR_RAID" = Fore.YELLOW,
-    "GAIN_FOR_CLAIM" = Fore.YELLOW,
-    "GAIN_FOR_WATCH" = Fore.YELLOW,
-    "BET_WIN" = Fore.GREEN,
-    "BET_LOSE" = Fore.RED,
-    "BET_REFUND" = Fore.RESET,
-    "BET_FILTERS" = Fore.MAGENTA,
-    "BET_GENERAL" = Fore.BLUE,
-    "BET_FAILED" = Fore.RED,
+    STREAMER_ONLINE = Fore.GREEN,
+    STREAMER_OFFLINE = Fore.RED,
+    GAIN_FOR_RAID = Fore.YELLOW,
+    GAIN_FOR_CLAIM = Fore.YELLOW,
+    GAIN_FOR_WATCH = Fore.YELLOW,
+    BET_WIN = Fore.GREEN,
+    BET_LOSE = Fore.RED,
+    BET_REFUND = Fore.RESET,
+    BET_FILTERS = Fore.MAGENTA,
+    BET_GENERAL = Fore.BLUE,
+    BET_FAILED = Fore.RED,
 )
 ```
 


### PR DESCRIPTION
# Description

Following the example for the color palette in the readme leads to a `  SyntaxError: keyword can't be an expression`.

## Type of change

- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
