### PR TITLE
WATCH_STREAK color

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ ColorPalette(
     GAIN_FOR_RAID = Fore.YELLOW,
     GAIN_FOR_CLAIM = Fore.YELLOW,
     GAIN_FOR_WATCH = Fore.YELLOW,
+    GAIN_FOR_WATCH_STREAK = Fore.YELLOW,
     BET_WIN = Fore.GREEN,
     BET_LOSE = Fore.RED,
     BET_REFUND = Fore.RESET,

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -52,6 +52,7 @@ class ColorPalette(object):
     GAIN_FOR_RAID = Fore.RESET
     GAIN_FOR_CLAIM = Fore.RESET
     GAIN_FOR_WATCH = Fore.RESET
+    GAIN_FOR_WATCH_STREAK = Fore.RESET
 
     BET_WIN = Fore.GREEN
     BET_LOSE = Fore.RED


### PR DESCRIPTION
# Description

Added `GAIN_FOR_WATCH_STREAK` into the palette with `RESET` default color.

## Type of change

- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
