### PR TITLE
Force user to enter his password when receiving invalid user/password response

### DIFF
--- a/TwitchChannelPointsMiner/classes/Exceptions.py
+++ b/TwitchChannelPointsMiner/classes/Exceptions.py
@@ -8,3 +8,7 @@ class StreamerIsOfflineException(Exception):
 
 class WrongCookiesException(Exception):
     pass
+
+
+class BadCredentialsException(Exception):
+    pass

--- a/TwitchChannelPointsMiner/classes/TwitchLogin.py
+++ b/TwitchChannelPointsMiner/classes/TwitchLogin.py
@@ -10,7 +10,10 @@ import pickle
 import browser_cookie3
 import requests
 
-from TwitchChannelPointsMiner.classes.Exceptions import WrongCookiesException, BadCredentialsException
+from TwitchChannelPointsMiner.classes.Exceptions import (
+    BadCredentialsException,
+    WrongCookiesException,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +110,9 @@ class TwitchLogin(object):
 
                         # If the password is loaded from run.py, require the user to fix it there.
                         if self.password is not None:
-                            raise BadCredentialsException("Username or password is incorrect.")
+                            raise BadCredentialsException(
+                                "Username or password is incorrect."
+                            )
 
                         # If the user didn't load the password from run.py we can just ask for it again.
                         break

--- a/TwitchChannelPointsMiner/classes/TwitchLogin.py
+++ b/TwitchChannelPointsMiner/classes/TwitchLogin.py
@@ -10,7 +10,7 @@ import pickle
 import browser_cookie3
 import requests
 
-from TwitchChannelPointsMiner.classes.Exceptions import WrongCookiesException
+from TwitchChannelPointsMiner.classes.Exceptions import WrongCookiesException, BadCredentialsException
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +104,12 @@ class TwitchLogin(object):
 
                     elif err_code == 3001:  # invalid password
                         logger.info("Invalid username or password, please try again.")
+
+                        # If the password is loaded from run.py, require the user to fix it there.
+                        if self.password is not None:
+                            raise BadCredentialsException("Username or password is incorrect.")
+
+                        # If the user didn't load the password from run.py we can just ask for it again.
                         break
                     elif err_code == 1000:
                         logger.info(


### PR DESCRIPTION
# Description

Currently when the script tries to log in, but uses the wrong password, it'll receive error 3001 and try to log in again.
This is fine if self.password is None, since it'll ask for a password, but if it isn't (meaning the password came from run.py), it'll keep trying to log in with the wrong password. (spamming Twitch with requests)
This can happen when you change your password but forget to update the run.py, or if you made a small mistake while entering the credentials.

~~Fixes # (issue)~~

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I made a test.py file with a copy of the TwitchLogin class. The send_login_request method has been replaced with one that prints something to the console and returns a 3001 error code. To test it I called the login_flow and checked the console for the result.
The current version of the script quickly spams the console full if self.password is not None. With my fix it raises a BadCredentialsException, stopping the script.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
