### PR TITLE
Allow mods to place predictions

### DIFF
--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -201,12 +201,12 @@ class TwitchChannelPointsMiner:
             # Populate the streamers with default values.
             # 1. Load channel points and auto-claim bonus
             # 2. Check if streamers are online
-            # 3. Check if the user is a Streamer. In thi case you can't do prediction
+            # 3. DEACTIVATED: Check if the user is a moderator. (was used before the 5th of April 2021 to deactivate predictions)
             for streamer in self.streamers:
                 time.sleep(random.uniform(0.3, 0.7))
                 self.twitch.load_channel_points_context(streamer)
                 self.twitch.check_streamer_online(streamer)
-                self.twitch.viewer_is_mod(streamer)
+                # self.twitch.viewer_is_mod(streamer)
 
             self.original_streamers = [
                 streamer.channel_points for streamer in self.streamers

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -207,8 +207,6 @@ class TwitchChannelPointsMiner:
                 self.twitch.load_channel_points_context(streamer)
                 self.twitch.check_streamer_online(streamer)
                 self.twitch.viewer_is_mod(streamer)
-                if streamer.viewer_is_mod is True:
-                    streamer.settings.make_predictions = False
 
             self.original_streamers = [
                 streamer.channel_points for streamer in self.streamers

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -261,31 +261,26 @@ class WebSocketsPool:
                                     ws.streamers[streamer_index].is_online
                                     and event.closing_bet_after(current_tmsp) > 0
                                 ):
-                                    if event.streamer.viewer_is_mod is True:
-                                        logger.info(
-                                            f"Sorry, you are moderator of {event.streamer}, so you can't bet!"
-                                        )
-                                    else:
-                                        ws.events_predictions[event_id] = event
-                                        start_after = event.closing_bet_after(
-                                            current_tmsp
-                                        )
+                                    ws.events_predictions[event_id] = event
+                                    start_after = event.closing_bet_after(
+                                        current_tmsp
+                                    )
 
-                                        place_bet_thread = Timer(
-                                            start_after,
-                                            ws.twitch.make_predictions,
-                                            (ws.events_predictions[event_id],),
-                                        )
-                                        place_bet_thread.daemon = True
-                                        place_bet_thread.start()
+                                    place_bet_thread = Timer(
+                                        start_after,
+                                        ws.twitch.make_predictions,
+                                        (ws.events_predictions[event_id],),
+                                    )
+                                    place_bet_thread.daemon = True
+                                    place_bet_thread.start()
 
-                                        logger.info(
-                                            f"Place the bet after: {start_after}s for: {ws.events_predictions[event_id]}",
-                                            extra={
-                                                "emoji": ":alarm_clock:",
-                                                "color": Settings.logger.color_palette.BET_START,
-                                            },
-                                        )
+                                    logger.info(
+                                        f"Place the bet after: {start_after}s for: {ws.events_predictions[event_id]}",
+                                        extra={
+                                            "emoji": ":alarm_clock:",
+                                            "color": Settings.logger.color_palette.BET_START,
+                                        },
+                                    )
 
                         elif (
                             message.type == "event-updated"

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -262,9 +262,7 @@ class WebSocketsPool:
                                     and event.closing_bet_after(current_tmsp) > 0
                                 ):
                                     ws.events_predictions[event_id] = event
-                                    start_after = event.closing_bet_after(
-                                        current_tmsp
-                                    )
+                                    start_after = event.closing_bet_after(current_tmsp)
 
                                     place_bet_thread = Timer(
                                         start_after,


### PR DESCRIPTION
# Description

Twitch now allows moderators to place bets. When they do they will however not be able to choose an outcome.

![image](https://user-images.githubusercontent.com/1688389/114266091-95d89080-99f4-11eb-8e14-8aadb4f702a7.png)
https://help.twitch.tv/s/article/channel-points-predictions

Fixes #138 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

- [x] Manually on a channel where I'm a mod. Prediction was placed successfully.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
