### PR TITLE
Prioritize streamer you're subscribed to (has points multiplier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ You can watch only two streamers per time. With `priority` settings, you can sel
 Available values are the following:
  - `STREAK` - Catch the watch streak from all streamers
  - `DROPS` - Claim all drops from streamers with drops tags enabled
- - `SUBSCRIBED` - Prioritize streamers you're subscribed to
+ - `SUBSCRIBED` - Prioritize streamers you're subscribed to (higher subscription tiers are mined first)
  - `ORDER` - Following the order of the list
  - `POINTS_ASCENDING` - On top the streamers with the lowest points
  - `POINTS_DESCEDING` - On top the streamers with the highest points

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ You can watch only two streamers per time. With `priority` settings, you can sel
 Available values are the following:
  - `STREAK` - Catch the watch streak from all streamers
  - `DROPS` - Claim all drops from streamers with drops tags enabled
+ - `SUBSCRIBED` - Prioritize streamers you're subscribed to
  - `ORDER` - Following the order of the list
  - `POINTS_ASCENDING` - On top the streamers with the lowest points
  - `POINTS_DESCEDING` - On top the streamers with the highest points

--- a/TwitchChannelPointsMiner/classes/Settings.py
+++ b/TwitchChannelPointsMiner/classes/Settings.py
@@ -5,6 +5,7 @@ class Priority(Enum):
     ORDER = auto()
     STREAK = auto()
     DROPS = auto()
+    SUBSCRIBED = auto()
     POINTS_ASCENDING = auto()
     POINTS_DESCEDING = auto()
 

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -323,6 +323,7 @@ class Twitch(object):
                         streamers_with_multiplier = sorted(
                             streamers_with_multiplier,
                             key=lambda x: streamers[x].total_points_multiplier(),
+                            reverse=True,
                         )
                         streamers_watching += streamers_with_multiplier[:2]
 

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -315,11 +315,16 @@ class Twitch(object):
                                     break
 
                     elif prior == Priority.SUBSCRIBED and len(streamers_watching) < 2:
-                        for index in streamers_index:
-                            if streamers[index].viewer_has_points_multiplier is True:
-                                streamers_watching.append(index)
-                                if len(streamers_watching) == 2:
-                                    break
+                        streamers_with_multiplier = [
+                            index
+                            for index in streamers_index
+                            if streamers[index].viewer_has_points_multiplier()
+                        ]
+                        streamers_with_multiplier = sorted(
+                            streamers_with_multiplier,
+                            key=lambda x: streamers[x].total_points_multiplier(),
+                        )
+                        streamers_watching += streamers_with_multiplier[:2]
 
                 """
                 Twitch has a limit - you can't watch more than 2 channels at one time.
@@ -393,7 +398,7 @@ class Twitch(object):
             channel = response["data"]["community"]["channel"]
             community_points = channel["self"]["communityPoints"]
             streamer.channel_points = community_points["balance"]
-            streamer.viewer_has_points_multiplier = len(community_points["activeMultipliers"]) > 0
+            streamer.activeMultipliers = community_points["activeMultipliers"]
 
             if community_points["availableClaim"] is not None:
                 self.claim_bonus(streamer, community_points["availableClaim"]["id"])

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -314,6 +314,13 @@ class Twitch(object):
                                 if len(streamers_watching) == 2:
                                     break
 
+                    elif prior == Priority.SUBSCRIBED and len(streamers_watching) < 2:
+                        for index in streamers_index:
+                            if streamers[index].viewer_has_points_multiplier is True:
+                                streamers_watching.append(index)
+                                if len(streamers_watching) == 2:
+                                    break
+
                 """
                 Twitch has a limit - you can't watch more than 2 channels at one time.
                 We take the first two streamers from the list as they have the highest priority (based on order or WatchStreak).
@@ -386,6 +393,7 @@ class Twitch(object):
             channel = response["data"]["community"]["channel"]
             community_points = channel["self"]["communityPoints"]
             streamer.channel_points = community_points["balance"]
+            streamer.viewer_has_points_multiplier = len(community_points["activeMultipliers"]) > 0
 
             if community_points["availableClaim"] is not None:
                 self.claim_bonus(streamer, community_points["availableClaim"]["id"])

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -70,7 +70,7 @@ class Streamer(object):
         "channel_points",
         "minute_watched_requests",
         "viewer_is_mod",
-        "viewer_has_points_multiplier",
+        "activeMultipliers",
         "irc_chat",
         "stream",
         "raid",
@@ -90,7 +90,7 @@ class Streamer(object):
         self.channel_points = 0
         self.minute_watched_requests = None
         self.viewer_is_mod = False
-        self.viewer_has_points_multiplier = False
+        self.activeMultipliers = None
         self.irc_chat = None
 
         self.stream = Stream()
@@ -168,6 +168,21 @@ class Streamer(object):
             and self.is_online is True
             and self.stream.drops_tags is True
             and self.stream.campaigns_ids != []
+        )
+
+    def viewer_has_points_multiplier(self):
+        return self.activeMultipliers is not None and len(self.activeMultipliers) > 0
+
+    def total_points_multiplier(self):
+        return (
+            sum(
+                map(
+                    lambda x: x["factor"],
+                    self.activeMultipliers,
+                ),
+            )
+            if self.activeMultipliers is not None
+            else 0
         )
 
     # === ANALYTICS === #

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -70,6 +70,7 @@ class Streamer(object):
         "channel_points",
         "minute_watched_requests",
         "viewer_is_mod",
+        "viewer_has_points_multiplier",
         "irc_chat",
         "stream",
         "raid",
@@ -89,6 +90,7 @@ class Streamer(object):
         self.channel_points = 0
         self.minute_watched_requests = None
         self.viewer_is_mod = False
+        self.viewer_has_points_multiplier = False
         self.irc_chat = None
 
         self.stream = Stream()


### PR DESCRIPTION
# Description

Fixes #166 #178. 

This will add a priority option to mine first the streamers you have points multiplier for (which is the same as being subscribed to a channel for now).
The channels with the highest multiplier (highest subscriber tier) will be mined first. If 2 channels have the same multiplier, the first one from the streamer list will be chosen.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

Manually. Setting priorities `[Priority.SUBSCRIBED, Priority.ORDER]` and a list of streamers `[subbed, not_subbed, not_subbed, subbed]`, only the 2 subbed streamers are being mined.

Though I couldn't test the "higher sub tier gets mined first" as I don't have subscriptions higher than T1.
Also I assumed that multipliers are added (like you got a multiplier from being a sub and another multiplier from another unknown reason). But it could very well be that only the higher one is applied. Would need to have people with several multipliers active to know that for sure. I guess this can be easily fixed later if my guess was wrong.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been updated in requirements.txt
