### PR TITLE
Do not iterate over all followed streamers as they can be blacklisted

### DIFF
--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -158,14 +158,8 @@ class TwitchChannelPointsMiner:
                 )
                 for username in followers_array:
                     if username not in streamers_dict and username not in blacklist:
+                        streamers_name.append(username)
                         streamers_dict[username] = username.lower().strip()
-            else:
-                followers_array = []
-
-            streamers_name = list(
-                OrderedDict.fromkeys(streamers_name + followers_array)
-            )
-            streamers_name = [name for name in streamers_name if name not in blacklist]
 
             logger.info(
                 f"Loading data for {len(streamers_name)} streamers. Please wait...",

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -8,7 +8,6 @@ import sys
 import threading
 import time
 import uuid
-from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
 


### PR DESCRIPTION
# Description

This change makes it so we don't iterate over the `provided streamers + ALL followed channels` but over `the resolved streamers` instead.

Fixes #203

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

I didn't, it's just pure guess from what is described in the issue. Maybe @vegych can test this to confirm.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been updated in requirements.txt
