### PR TITLE
Added a Dockerfile for building container images and some documentation

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -9,6 +9,11 @@ and cares for running `run.py` when the container is started.
 `run.py` resides on the host system and needs to be mapped into the container 
 during startup since it contains the configuration.
 
+It is recommended to also map the folders *cookies* and *analytics* to a volume 
+or folder on the host system to make sure that cookies (important to stay logged in 
+if 2FA is enabled in Twitch) and analytics is preserved even in case of container 
+re-creation or updates.
+
 
 ## Building the Docker image
 
@@ -31,14 +36,22 @@ mapped into the container - which is perfectly fine.
 ## Running the docker image
 
 ```bash
-docker run -d -p 5000:5000 -v /path/to/your/run.py:/Twitch-Channel-Points-Miner-v2/run.py --name miner --restart unless-stopped tcpm
+docker run -d -p 5000:5000 \
+-v /path/to/your/run.py:/Twitch-Channel-Points-Miner-v2/run.py \
+-v /path/to/your/cookies/folder:/Twitch-Channel-Points-Miner-v2/cookies \
+-v /path/to/your/analytics/folder:/Twitch-Channel-Points-Miner-v2/analytics \
+--name miner --restart unless-stopped tcpm
 ```
 
 Probably your Twitch account needs a verfication code on the first login from a new machine. 
 In This case start the container attached for the first run:
 
 ```bash
-docker run -it -p 5000:5000 -v /path/to/your/run.py:/Twitch-Channel-Points-Miner-v2/run.py --name miner tcpm
+docker run -it -p 5000:5000 \
+-v /path/to/your/run.py:/Twitch-Channel-Points-Miner-v2/run.py \
+-v /path/to/your/cookies/folder:/Twitch-Channel-Points-Miner-v2/cookies \
+-v /path/to/your/analytics/folder:/Twitch-Channel-Points-Miner-v2/analytics \
+--name miner tcpm
 ```
 
 After that, you can start the container in detached mode:

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,48 @@
+# Run Twitch Channel Points Miner v2 in a Docker container
+
+Docker offers an easy way to run an app in an isolated space, bundled with its 
+requirements and separated from the host system and other containers.
+
+The Dockerfile uses a small python image, installs all requirements, the app
+and cares for running `run.py` when the container is started.
+
+`run.py` resides on the host system and needs to be mapped into the container 
+during startup since it contains the configuration.
+
+
+## Building the Docker image
+
+With Docker installed, run:
+
+```bash
+docker build -t tcpm .
+```
+
+After the build, the container image can easily be tested by running:
+
+```bash
+docker run -it --rm tcpm
+```
+
+This should print a message which tells that there is no actual `run.py` 
+mapped into the container - which is perfectly fine.
+
+
+## Running the docker image
+
+```bash
+docker run -d -p 5000:5000 -v /path/to/your/run.py:/Twitch-Channel-Points-Miner-v2/run.py --name miner --restart unless-stopped tcpm
+```
+
+Probably your Twitch account needs a verfication code on the first login from a new machine. 
+In This case start the container attached for the first run:
+
+```bash
+docker run -it -p 5000:5000 -v /path/to/your/run.py:/Twitch-Channel-Points-Miner-v2/run.py --name miner tcpm
+```
+
+After that, you can start the container in detached mode:
+
+```bash
+docker start --restart unless-stopped miner
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.9-slim-buster
+COPY . /Twitch-Channel-Points-Miner-v2
+WORKDIR /Twitch-Channel-Points-Miner-v2
+RUN apt-get update \
+ && apt-get install gcc libffi-dev rustc zlib1g-dev libjpeg-dev libssl-dev --assume-yes \
+ && pip install -r requirements.txt \
+ && pip cache purge \
+ && apt-get remove gcc rustc --assume-yes \
+ && apt-get autoremove --assume-yes \
+ && rm -rf /var/lib/apt/lists/* \
+ && echo 'print("The container works, but there is no startup config provided.\
+ \\nMake sure to map your run.py to /Twitch-Channel-Points-Miner-v2/run.py\
+ when starting the container.");' > run.py
+CMD python run.py


### PR DESCRIPTION
# Description

A first approach in creating a docker image to get rid of python dependencies. 

Fixes #79 (partly)
My focus was on having a small Docker image which gets me rid of the python dependencies on my Raspberry Pi.
Following my approach, run.py has to be mapped into the container. However, I like the approach described in #79. Probably something to consider in the future. See this one as a first step.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

I built the docker image on a Raspberry Pi (docker-ce) and on the latest MacOS (Docker Desktop) and was able to run the app within the container.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md) ... created DOCKE.md
- [x] My changes generate no new warnings
- [n/a] Any dependent changes have been updated in requirements.txt
