### PR TITLE
Custom bet delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ from colorama import Fore
 from TwitchChannelPointsMiner import TwitchChannelPointsMiner
 from TwitchChannelPointsMiner.logger import LoggerSettings, ColorPalette
 from TwitchChannelPointsMiner.classes.Settings import Priority
-from TwitchChannelPointsMiner.classes.entities.Bet import Strategy, BetSettings, Condition, OutcomeKeys, FilterCondition
+from TwitchChannelPointsMiner.classes.entities.Bet import Strategy, BetSettings, Condition, OutcomeKeys, FilterCondition, DelayMode
 from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer, StreamerSettings
 
 twitch_miner = TwitchChannelPointsMiner(
@@ -217,7 +217,9 @@ twitch_miner = TwitchChannelPointsMiner(
             percentage_gap=20,                  # Gap difference between outcomesA and outcomesB (for SMART stragegy)
             max_points=50000,                   # If the x percentage of your channel points is gt bet_max_points set this value
             stealth_mode=True,                  # If the calculated amount of channel points is GT the highest bet, place the highest value minus 1-2 points #33
-            filter_condition=FilterCondition(
+           delay_mode=DelayMode.FROM_END,       # When placing a bet, we will wait until `delay` seconds before the end of the timer
+           delay=6,
+           filter_condition=FilterCondition(
                 by=OutcomeKeys.TOTAL_USERS,    # Where apply the filter. Allowed [PERCENTAGE_USERS, ODDS_PERCENTAGE, ODDS, TOP_POINTS, TOTAL_USERS, TOTAL_POINTS]
                 where=Condition.LTE,           # 'by' must be [GT, LT, GTE, LTE] than value
                 value=800
@@ -349,6 +351,8 @@ ColorPalette(
 | `max_points`       	| int             	| 50000   	| If the x percentage of your channel points is GT bet_max_points set this value                                 	                                                                          |
 | `stealth_mode`     	| bool            	| False   	| If the calculated amount of channel points is GT the highest bet, place the highest value minus 1-2 points [#33](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/33)      |
 | `join_chat` 	        | bool 	            | True    	| Join IRC-Chat to appear online in chat and attempt to get StreamElements channel points and increase view-time  [#47](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/47) |
+| `delay_mode` 	        | DelayMode         | FROM_END	| Define how is calculating the waiting time before placing a bet |
+| `delay` 	            | float             | 6     	| Value to be used to calculate bet delay depending on `delay_mode` value |
 
 #### Bet strategy
 
@@ -393,6 +397,18 @@ Allowed values for `where` are: `GT, LT, GTE, LTE`
 `FilterCondition(by=OutcomeKeys.ODDS, where=Condition.GTE, value=1.3)`
 - If you want to place the bet ONLY if the highest bet is lower than 2000
 `FilterCondition(by=OutcomeKeys.TOP_POINTS, where=Condition.LT, value=2000)`
+
+### DelayMode
+
+- **FROM_START**: Will wait `delay` seconds from when the bet was opened
+- **FROM_END**: Will until there is `delay` seconds left to place the bet
+- **PERCENTAGE**: Will place the bet when `delay` percent of the set timer is elapsed
+
+Here a concrete example. Let's suppose we have a bet that is opened with a timer of 10 minutes:
+
+- **FROM_START** with `delay=20`: The bet will be placed 20s after the bet is opened
+- **FROM_END** with `delay=20`: The bet will be placed 20s before the end of the bet (so 9mins 40s after the bet is opened)
+- **PERCENTAGE** with `delay=0.2`: The bet will be placed when the timer went down by 20% (so 2mins after the bet is opened)
 
 ## Analytics
 We have recently introduced a little frontend where you can show with a chart you points trend. The script will spawn a Flask web-server on your machine where you can select binding address and port.

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ Allowed values for `where` are: `GT, LT, GTE, LTE`
 - **FROM_END**: Will until there is `delay` seconds left to place the bet
 - **PERCENTAGE**: Will place the bet when `delay` percent of the set timer is elapsed
 
-Here a concrete example. Let's suppose we have a bet that is opened with a timer of 10 minutes:
+Here's a concrete example. Let's suppose we have a bet that is opened with a timer of 10 minutes:
 
 - **FROM_START** with `delay=20`: The bet will be placed 20s after the bet is opened
 - **FROM_END** with `delay=20`: The bet will be placed 20s before the end of the bet (so 9mins 40s after the bet is opened)

--- a/README.md
+++ b/README.md
@@ -350,9 +350,9 @@ ColorPalette(
 | `percentage_gap`   	| int             	| 20      	| Gap difference between outcomesA and outcomesB (for SMART stragegy)                                            	                                                                          |
 | `max_points`       	| int             	| 50000   	| If the x percentage of your channel points is GT bet_max_points set this value                                 	                                                                          |
 | `stealth_mode`     	| bool            	| False   	| If the calculated amount of channel points is GT the highest bet, place the highest value minus 1-2 points [#33](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/33)      |
-| `join_chat` 	        | bool 	            | True    	| Join IRC-Chat to appear online in chat and attempt to get StreamElements channel points and increase view-time  [#47](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/47) |
-| `delay_mode` 	        | DelayMode         | FROM_END	| Define how is calculating the waiting time before placing a bet |
-| `delay` 	            | float             | 6     	| Value to be used to calculate bet delay depending on `delay_mode` value |
+| `join_chat` 	        | bool 	            	| True    	| Join IRC-Chat to appear online in chat and attempt to get StreamElements channel points and increase view-time  [#47](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/47) |
+| `delay_mode` 	        | DelayMode         	| FROM_END	| Define how is calculating the waiting time before placing a bet |
+| `delay` 	        | float             	| 6     	| Value to be used to calculate bet delay depending on `delay_mode` value |
 
 #### Bet strategy
 

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -247,7 +247,9 @@ class WebSocketsPool:
                                     event_dict["prediction_window_seconds"]
                                 )
                                 # Reduce prediction window by 3/6s - Collect more accurate data for decision
-                                prediction_window_seconds = ws.streamers[streamer_index].get_prediction_window(prediction_window_seconds)
+                                prediction_window_seconds = ws.streamers[
+                                    streamer_index
+                                ].get_prediction_window(prediction_window_seconds)
                                 event = EventPrediction(
                                     ws.streamers[streamer_index],
                                     event_id,

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -247,7 +247,7 @@ class WebSocketsPool:
                                     event_dict["prediction_window_seconds"]
                                 )
                                 # Reduce prediction window by 3/6s - Collect more accurate data for decision
-                                prediction_window_seconds -= random.uniform(3, 6)
+                                prediction_window_seconds = ws.streamers[streamer_index].get_prediction_window(prediction_window_seconds)
                                 event = EventPrediction(
                                     ws.streamers[streamer_index],
                                     event_id,

--- a/TwitchChannelPointsMiner/classes/entities/Bet.py
+++ b/TwitchChannelPointsMiner/classes/entities/Bet.py
@@ -41,6 +41,15 @@ class OutcomeKeys(object):
     DECISION_POINTS = "decision_points"
 
 
+class DelayMode(Enum):
+    FROM_START = auto()
+    FROM_END = auto()
+    PERCENTAGE = auto()
+
+    def __str__(self):
+        return self.name
+
+
 class FilterCondition(object):
     __slots__ = [
         "by",
@@ -65,6 +74,8 @@ class BetSettings(object):
         "max_points",
         "stealth_mode",
         "filter_condition",
+        "delay",
+        "delay_mode"
     ]
 
     def __init__(
@@ -75,6 +86,8 @@ class BetSettings(object):
         max_points: int = None,
         stealth_mode: bool = None,
         filter_condition: FilterCondition = None,
+        delay: float = None,
+        delay_mode: DelayMode = None
     ):
         self.strategy = strategy
         self.percentage = percentage
@@ -82,6 +95,8 @@ class BetSettings(object):
         self.max_points = max_points
         self.stealth_mode = stealth_mode
         self.filter_condition = filter_condition
+        self.delay = delay
+        self.delay_mode = delay_mode
 
     def default(self):
         self.strategy = self.strategy if not None else Strategy.SMART
@@ -89,6 +104,8 @@ class BetSettings(object):
         self.percentage_gap = self.percentage_gap if not None else 20
         self.max_points = self.max_points if not None else 50000
         self.stealth_mode = self.stealth_mode if not None else False
+        self.delay = self.delay if not None else 6
+        self.delay_mode = self.delay_mode if not None else DelayMode.FROM_END
 
     def __repr__(self):
         return f"BetSettings(strategy={self.strategy}, percentage={self.percentage}, percentage_gap={self.percentage_gap}, max_points={self.max_points}, stealth_mode={self.stealth_mode})"

--- a/TwitchChannelPointsMiner/classes/entities/Bet.py
+++ b/TwitchChannelPointsMiner/classes/entities/Bet.py
@@ -75,7 +75,7 @@ class BetSettings(object):
         "stealth_mode",
         "filter_condition",
         "delay",
-        "delay_mode"
+        "delay_mode",
     ]
 
     def __init__(
@@ -87,7 +87,7 @@ class BetSettings(object):
         stealth_mode: bool = None,
         filter_condition: FilterCondition = None,
         delay: float = None,
-        delay_mode: DelayMode = None
+        delay_mode: DelayMode = None,
     ):
         self.strategy = strategy
         self.percentage = percentage

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from threading import Lock
 
 from TwitchChannelPointsMiner.classes.Chat import ThreadChat
-from TwitchChannelPointsMiner.classes.entities.Bet import BetSettings
+from TwitchChannelPointsMiner.classes.entities.Bet import BetSettings, DelayMode
 from TwitchChannelPointsMiner.classes.entities.Stream import Stream
 from TwitchChannelPointsMiner.classes.Settings import Settings
 from TwitchChannelPointsMiner.constants import URL
@@ -184,6 +184,18 @@ class Streamer(object):
             if self.activeMultipliers is not None
             else 0
         )
+
+    def get_prediction_window(self, prediction_window_seconds):
+        delay_mode = self.settings.bet.delay_mode
+        delay = self.settings.bet.delay
+        if delay_mode == DelayMode.FROM_START:
+            return delay
+        elif delay_mode == DelayMode.FROM_END:
+            return prediction_window_seconds - delay
+        elif delay_mode == DelayMode.PERCENTAGE:
+            return prediction_window_seconds * delay
+        else:
+            return prediction_window_seconds
 
     # === ANALYTICS === #
     def persistent_annotations(self, event_type, event_text):

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -189,9 +189,9 @@ class Streamer(object):
         delay_mode = self.settings.bet.delay_mode
         delay = self.settings.bet.delay
         if delay_mode == DelayMode.FROM_START:
-            return delay
+            return min(delay, prediction_window_seconds)
         elif delay_mode == DelayMode.FROM_END:
-            return prediction_window_seconds - delay
+            return max(prediction_window_seconds - delay, 0)
         elif delay_mode == DelayMode.PERCENTAGE:
             return prediction_window_seconds * delay
         else:


### PR DESCRIPTION
# Description

Some channels (like rainbow6) make predictions with a very long timer (something like 30mins) and then a moderator closes it manually. This makes the current betting system not work properly on these channels as it places the bet 3~6 seconds before the end of the bet (but a moderator will close it way before the end).

This PR aims to give some control to the user on this delay. Two configuration keys have been added.

- `delay_mode` to indicate how the delay is calculated (from start, from end, percentage)
- `delay` which is a parameter for the `delay_mode` action (number of seconds from start/end, the actual percentage)

Fixes #222

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

Maybe @Pajkaa (and whoever wants) can try this too if they want.

For now I have tried the following :

* `Streamer("xxxx", settings=StreamerSettings(bet=BetSettings(delay=300, delay_mode=DelayMode.FROM_START))),`
This worked fine and let to a bet being placed 5min after the opening `INFO - TwitchChannelPointsMiner.classes.WebSocketsPool - [on_message]: Place the bet after: 299.98s for: EventPrediction: xxxx (yyyyk points) - Who Will Win` even though the bet was open for more than 5mins.

Settings that were not overloaded behaved the same as it is currently (a few seconds (6) before the end).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been updated in requirements.txt
