### PR TITLE
Fix setting default values for bet settings

### DIFF
--- a/TwitchChannelPointsMiner/classes/entities/Bet.py
+++ b/TwitchChannelPointsMiner/classes/entities/Bet.py
@@ -102,14 +102,14 @@ class BetSettings(object):
         self.delay_mode = delay_mode
 
     def default(self):
-        self.strategy = self.strategy if not None else Strategy.SMART
-        self.percentage = self.percentage if not None else 5
-        self.percentage_gap = self.percentage_gap if not None else 20
-        self.max_points = self.max_points if not None else 50000
-        self.minimum_points = self.minimum_points if not None else 0
-        self.stealth_mode = self.stealth_mode if not None else False
-        self.delay = self.delay if not None else 6
-        self.delay_mode = self.delay_mode if not None else DelayMode.FROM_END
+        self.strategy = self.strategy if self.strategy is not None else Strategy.SMART
+        self.percentage = self.percentage if self.percentage is not None else 5
+        self.percentage_gap = self.percentage_gap if self.percentage_gap is not None else 20
+        self.max_points = self.max_points if self.max_points is not None else 50000
+        self.minimum_points = self.minimum_points if self.minimum_points is not None else 0
+        self.stealth_mode = self.stealth_mode if self.stealth_mode is not None else False
+        self.delay = self.delay if self.delay is not None else 6
+        self.delay_mode = self.delay_mode if self.delay_mode is not None else DelayMode.FROM_END
 
     def __repr__(self):
         return f"BetSettings(strategy={self.strategy}, percentage={self.percentage}, percentage_gap={self.percentage_gap}, max_points={self.max_points}, minimum_points={self.minimum_points}, stealth_mode={self.stealth_mode})"


### PR DESCRIPTION
# Description

Fixes an issue with the `BetSettings.default` method that didn't set the default values correctly.

The defaults were set by using:

```python
self.<setting> = self.<setting> if not None else `<default value>`
```

The `if not None` always evaluates to `True`, so the `else` was never executed.

Fixes #262 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Logging the values used when bets were placed (logging not included in this PR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been updated in requirements.txt
