### PR TITLE
Use GraphQL instead of Helix API

### DIFF
--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -240,10 +240,11 @@ class TwitchChannelPointsMiner:
             )
 
             # Subscribe to community-points-user. Get update for points spent or gains
+            user_id = self.twitch.twitch_login.get_user_id()
             self.ws_pool.submit(
                 PubsubTopic(
                     "community-points-user-v1",
-                    user_id=self.twitch.twitch_login.get_user_id(),
+                    user_id=user_id,
                 )
             )
 
@@ -252,7 +253,7 @@ class TwitchChannelPointsMiner:
                 self.ws_pool.submit(
                     PubsubTopic(
                         "predictions-user-v1",
-                        user_id=self.twitch.twitch_login.get_user_id(),
+                        user_id=user_id,
                     )
                 )
 

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -304,7 +304,8 @@ class TwitchChannelPointsMiner:
                     streamer.irc_chat.join()
 
         self.running = self.twitch.running = False
-        self.ws_pool.end()
+        if self.ws_pool is not None:
+            self.ws_pool.end()
 
         if self.minute_watcher_thread is not None:
             self.minute_watcher_thread.join()

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -143,7 +143,6 @@ class Twitch(object):
                 streamer.set_offline()
 
     def get_channel_id(self, streamer_username):
-        # json_response = self.__do_helix_request(f"/users?login={streamer_username}")
         json_data = copy.deepcopy(GQLOperations.ReportMenuItem)
         json_data["variables"] = {"channelLogin": streamer_username}
         json_response = self.post_gql_request(json_data)
@@ -155,26 +154,6 @@ class Twitch(object):
             raise StreamerDoesNotExistException
         else:
             return json_response["data"]["user"]["id"]
-
-    """
-    def get_followers(self, first=100):
-        followers = []
-        pagination = {}
-        while 1:
-            query = f"/users/follows?from_id={self.twitch_login.get_user_id()}&first={first}"
-            if pagination != {}:
-                query += f"&after={pagination['cursor']}"
-
-            json_response = self.__do_helix_request(query)
-            pagination = json_response["pagination"]
-            followers += [fw["to_login"].lower() for fw in json_response["data"]]
-            time.sleep(random.uniform(0.3, 0.7))
-
-            if pagination == {}:
-                break
-
-        return followers
-    """
 
     def get_followers(self):
         json_data = copy.deepcopy(GQLOperations.PersonalSections)
@@ -188,6 +167,7 @@ class Twitch(object):
                 return [
                     fw["user"]["login"]
                     for fw in json_response["data"]["personalSections"][0]["items"]
+                    if fw["user"] is not None
                 ]
         except KeyError:
             return []

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -355,14 +355,12 @@ class Twitch(object):
                                         drop.has_preconditions_met is not False
                                         and drop.is_printable is True
                                     ):
-                                        # print("=" * 125)
                                         logger.info(
                                             f"{streamers[index]} is streaming {streamers[index].stream}"
                                         )
                                         logger.info(f"Campaign: {campaign}")
                                         logger.info(f"Drop: {drop}")
                                         logger.info(f"{drop.progress_bar()}")
-                                        # print("=" * 125)
 
                     except requests.exceptions.ConnectionError as e:
                         logger.error(f"Error while trying to send minute watched: {e}")
@@ -534,7 +532,9 @@ class Twitch(object):
                 }
 
             response = self.post_gql_request(json_data)
-            result += list(map(lambda x: x["data"]["user"]["dropCampaign"], response))
+            for r in response:
+                if r["data"]["user"] is not None:
+                    result.append(r["data"]["user"]["dropCampaign"])
         return result
 
     def __sync_campaigns(self, campaigns):

--- a/TwitchChannelPointsMiner/classes/TwitchLogin.py
+++ b/TwitchChannelPointsMiner/classes/TwitchLogin.py
@@ -179,20 +179,7 @@ class TwitchLogin(object):
         if self.token is None:
             return False
 
-        json_data = copy.deepcopy(GQLOperations.ReportMenuItem)
-        json_data["variables"] = {"channelLogin": self.username}
-        response = self.session.post(GQLOperations.url, json=json_data)
-
-        if response.status_code == 200:
-            json_response = response.json()
-            if (
-                "data" in json_response
-                and "user" in json_response["data"]
-                and json_response["data"]["user"]["id"] is not None
-            ):
-                self.user_id = json_response["data"]["user"]["id"]
-                self.login_check_result = True
-
+        self.login_check_result = self.__set_user_id()
         return self.login_check_result
 
     def save_cookies(self, cookies_file):
@@ -211,6 +198,7 @@ class TwitchLogin(object):
             if cookie["name"] == key:
                 if cookie["value"] is not None:
                     return cookie["value"]
+        return None
 
     def load_cookies(self, cookies_file):
         if os.path.isfile(cookies_file):
@@ -219,7 +207,30 @@ class TwitchLogin(object):
             raise WrongCookiesException("There must be a cookies file!")
 
     def get_user_id(self):
-        return int(self.get_cookie_value("persistent").split("%")[0])
+        persistent = self.get_cookie_value("persistent")
+        user_id = (
+            int(persistent.split("%")[0]) if persistent is not None else self.user_id
+        )
+        if user_id is None:
+            if self.__set_user_id() is True:
+                return self.user_id
+        return user_id
+
+    def __set_user_id(self):
+        json_data = copy.deepcopy(GQLOperations.ReportMenuItem)
+        json_data["variables"] = {"channelLogin": self.username}
+        response = self.session.post(GQLOperations.url, json=json_data)
+
+        if response.status_code == 200:
+            json_response = response.json()
+            if (
+                "data" in json_response
+                and "user" in json_response["data"]
+                and json_response["data"]["user"]["id"] is not None
+            ):
+                self.user_id = json_response["data"]["user"]["id"]
+                return True
+        return False
 
     def get_auth_token(self):
         return self.get_cookie_value("auth-token")

--- a/TwitchChannelPointsMiner/classes/TwitchLogin.py
+++ b/TwitchChannelPointsMiner/classes/TwitchLogin.py
@@ -180,7 +180,7 @@ class TwitchLogin(object):
             return False
 
         json_data = copy.deepcopy(GQLOperations.ReportMenuItem)
-        json_data["variables"] = {"channelLogin": self.usrername}
+        json_data["variables"] = {"channelLogin": self.username}
         response = self.session.post(GQLOperations.url, json=json_data)
 
         if response.status_code == 200:

--- a/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
+++ b/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
@@ -43,7 +43,6 @@ class TwitchWebSocket(WebSocketApp):
         data = {"topics": [str(topic)]}
         if topic.is_user_topic() and auth_token is not None:
             data["auth_token"] = auth_token
-
         nonce = create_nonce()
         self.send({"type": "LISTEN", "nonce": nonce, "data": data})
 

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -142,7 +142,6 @@ class WebSocketsPool:
             # Why not create a new ws on the same array index? Let's try.
             self = ws.parent_pool
             self.ws[ws.index] = self.__new(ws.index)  # Create a new connection.
-            # self.ws[ws.index].topics = ws.topics
 
             self.__start(ws.index)  # Start a new thread.
             time.sleep(30)

--- a/TwitchChannelPointsMiner/constants.py
+++ b/TwitchChannelPointsMiner/constants.py
@@ -1,6 +1,5 @@
 # Twitch endpoints
 URL = "https://www.twitch.tv"
-API = "https://api.twitch.tv"
 IRC = "irc.chat.twitch.tv"
 IRC_PORT = 6667
 WEBSOCKET = "wss://pubsub-edge.twitch.tv/v1"
@@ -118,7 +117,7 @@ class GQLOperations:
         "extensions": {
             "persistedQuery": {
                 "version": 1,
-                "sha256Hash": "14b5e8a50777165cfc3971e1d93b4758613fe1c817d5542c398dce70b7a45c05",  # "7da6078b1bfa2f0a4dd061cb47bdcd1ffddf31cccadd966ec192e4cd06666e2b",
+                "sha256Hash": "14b5e8a50777165cfc3971e1d93b4758613fe1c817d5542c398dce70b7a45c05",
             }
         },
     }
@@ -128,6 +127,33 @@ class GQLOperations:
             "persistedQuery": {
                 "version": 1,
                 "sha256Hash": "b19ee96a0e79e3f8281c4108bc4c7b3f232266db6f96fd04a339ab393673a075",
+            }
+        },
+    }
+    ReportMenuItem = {  # Use for replace https://api.twitch.tv/helix/users?login={self.username}
+        "operationName": "ReportMenuItem",
+        "extensions": {
+            "persistedQuery": {
+                "version": 1,
+                "sha256Hash": "8f3628981255345ca5e5453dfd844efffb01d6413a9931498836e6268692a30c",
+            }
+        },
+    }
+    PersonalSections = {
+        "operationName": "PersonalSections",
+        "variables": {
+            "input": {
+                "sectionInputs": ["FOLLOWED_SECTION"],
+                "recommendationContext": {"platform": "web"},
+            },
+            "channelLogin": None,
+            "withChannelUser": False,
+            "creatorAnniversariesExperimentEnabled": False,
+        },
+        "extensions": {
+            "persistedQuery": {
+                "version": 1,
+                "sha256Hash": "9fbdfb00156f754c26bde81eb47436dee146655c92682328457037da1a48ed39",
             }
         },
     }


### PR DESCRIPTION
# Description

The current Client-ID seems to don't work any more for the Helix API request.
Current workaround It's to use the GraphQL request to get streamer_id and followers list.

Fixes #281 #284 #292 #293

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
