### PR TITLE
Betting strategy: Smart money #331

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ ColorPalette(
 - **MOST_VOTED**: Select the option most voted based on users count
 - **HIGH_ODDS**: Select the option with the highest odds
 - **PERCENTAGE**: Select the option with the highest percentage based on odds (It's the same that show Twitch) - Should be the same as select LOWEST_ODDS
+- **SMART_MONEY**: Select the option with the highest points placed. [#331](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/331)
 - **SMART**: If the majority in percent chose an option, then follow the other users, otherwise select the option with the highest odds
 
 ![Screenshot](https://raw.githubusercontent.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/master/assets/prediction.png)

--- a/TwitchChannelPointsMiner/classes/entities/Bet.py
+++ b/TwitchChannelPointsMiner/classes/entities/Bet.py
@@ -11,6 +11,7 @@ class Strategy(Enum):
     MOST_VOTED = auto()
     HIGH_ODDS = auto()
     PERCENTAGE = auto()
+    SMART_MONEY = auto()
     SMART = auto()
 
     def __str__(self):
@@ -260,6 +261,8 @@ class Bet(object):
             self.decision["choice"] = self.__return_choice(OutcomeKeys.ODDS)
         elif self.settings.strategy == Strategy.PERCENTAGE:
             self.decision["choice"] = self.__return_choice(OutcomeKeys.ODDS_PERCENTAGE)
+        elif self.settings.strategy == Strategy.SMART_MONEY:
+            self.decision["choice"] = self.__return_choice(OutcomeKeys.TOP_POINTS)
         elif self.settings.strategy == Strategy.SMART:
             difference = abs(
                 self.outcomes[0][OutcomeKeys.PERCENTAGE_USERS]


### PR DESCRIPTION
# Description

When a prediction is live, Twitch shows the following information: total amount placed on each side (giving the odds), number of bettors on each side, and the largest bet placed on each side. The largest bet placed on each side can usually give a clue as to where the smart money is betting on because the people with the most channel points have usually watched the channel for the longest amount of time (have the most knowledge) and/or have won the most bets (are good at predictions). This strategy would bet on the side that has the largest individual bet placed.

Fixes #331 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
