### PR TITLE
error with the old websocket

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.25.1
-websocket-client==1.0.1
+websocket-client==1.2.3
 browser_cookie3==0.12.1
 pillow==8.3.2
 python-dateutil==2.8.1


### PR DESCRIPTION
pip install websocket-client==1.2.3
Fixes # (issue)

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

when I installed pip3 install websocket-client and it worked without errors

# Checklist:


- [ ] My changes generate no new warnings
