### PR TITLE
Logging console handler / file handler put on a different thread

### DIFF
--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -64,6 +64,7 @@ class TwitchChannelPointsMiner:
         "start_datetime",
         "original_streamers",
         "logs_file",
+        "queue_listener",
     ]
 
     def __init__(
@@ -108,7 +109,7 @@ class TwitchChannelPointsMiner:
         self.start_datetime = None
         self.original_streamers = []
 
-        self.logs_file = configure_loggers(self.username, logger_settings)
+        self.logs_file,self.queue_listener = configure_loggers(self.username, logger_settings)
 
         # Check for the latest version of the script
         current_version, github_version = check_versions()
@@ -347,6 +348,9 @@ class TwitchChannelPointsMiner:
                 streamer.mutex.release()
 
         self.__print_report()
+
+        # Stop the queue listener to make sure all messages have been logged
+        self.queue_listener.stop()
 
         sys.exit(0)
 

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -109,7 +109,9 @@ class TwitchChannelPointsMiner:
         self.start_datetime = None
         self.original_streamers = []
 
-        self.logs_file,self.queue_listener = configure_loggers(self.username, logger_settings)
+        self.logs_file, self.queue_listener = configure_loggers(
+            self.username, logger_settings
+        )
 
         # Check for the latest version of the script
         current_version, github_version = check_versions()

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -3,7 +3,8 @@ import os
 import platform
 import queue
 from datetime import datetime
-from logging.handlers import TimedRotatingFileHandler,QueueHandler,QueueListener
+from logging.handlers import (QueueHandler, QueueListener,
+                              TimedRotatingFileHandler)
 from pathlib import Path
 
 import emoji
@@ -165,7 +166,7 @@ def configure_loggers(username, settings):
     queue_handler = QueueHandler(logger_queue)
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
-    # Add the queue handler to the root logger 
+    # Add the queue handler to the root logger
     # Send log messages to another thread through the queue
     root_logger.addHandler(queue_handler)
 
@@ -215,12 +216,16 @@ def configure_loggers(username, settings):
             )
         )
         file_handler.setLevel(settings.file_level)
-        
+
         # Add logger handlers to the logger queue and start the process
-        queue_listener = QueueListener(logger_queue,file_handler,console_handler,respect_handler_level=True)
+        queue_listener = QueueListener(
+            logger_queue, file_handler, console_handler, respect_handler_level=True
+        )
         queue_listener.start()
         return logs_file, queue_listener
     else:
-        queue_listener = QueueListener(logger_queue,console_handler,respect_handler_level=True)
+        queue_listener = QueueListener(
+            logger_queue, console_handler, respect_handler_level=True
+        )
         queue_listener.start()
         return None, queue_listener

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -219,8 +219,8 @@ def configure_loggers(username, settings):
         # Add logger handlers to the logger queue and start the process
         queue_listener = QueueListener(logger_queue,file_handler,console_handler,respect_handler_level=True)
         queue_listener.start()
-        return logs_file
+        return logs_file, queue_listener
     else:
         queue_listener = QueueListener(logger_queue,console_handler,respect_handler_level=True)
         queue_listener.start()
-        return None
+        return None, queue_listener

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -3,8 +3,7 @@ import os
 import platform
 import queue
 from datetime import datetime
-from logging.handlers import (QueueHandler, QueueListener,
-                              TimedRotatingFileHandler)
+from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
 from pathlib import Path
 
 import emoji

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -1,8 +1,9 @@
 import logging
 import os
 import platform
+import queue
 from datetime import datetime
-from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import TimedRotatingFileHandler,QueueHandler,QueueListener
 from pathlib import Path
 
 import emoji
@@ -159,8 +160,14 @@ def configure_loggers(username, settings):
     if settings.colored is True:
         init(autoreset=True)
 
+    # Queue handler that will handle the logger queue
+    logger_queue = queue.Queue(-1)
+    queue_handler = QueueHandler(logger_queue)
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
+    # Add the queue handler to the root logger 
+    # Send log messages to another thread through the queue
+    root_logger.addHandler(queue_handler)
 
     console_handler = logging.StreamHandler()
     console_handler.setLevel(settings.console_level)
@@ -208,10 +215,12 @@ def configure_loggers(username, settings):
             )
         )
         file_handler.setLevel(settings.file_level)
-
-        root_logger.addHandler(file_handler)
-        root_logger.addHandler(console_handler)
+        
+        # Add logger handlers to the logger queue and start the process
+        queue_listener = QueueListener(logger_queue,file_handler,console_handler,respect_handler_level=True)
+        queue_listener.start()
         return logs_file
     else:
-        root_logger.addHandler(console_handler)
+        queue_listener = QueueListener(logger_queue,console_handler,respect_handler_level=True)
+        queue_listener.start()
         return None


### PR DESCRIPTION
# Description

The logging console handler and file handler were put on a different thread. This was done through the logging handler [QueueHandler](https://docs.python.org/3/library/logging.handlers.html#queuehandler): 
>Along with the [QueueListener](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.QueueListener) class, [QueueHandler](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.QueueHandler) can be used to let handlers do their work on a separate thread from the one which does the logging. This is important in web applications and also other service applications where threads servicing clients need to respond as quickly as possible, while any potentially slow operations (such as sending an email via [SMTPHandler](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.SMTPHandler)) are done on a separate thread.

The motivation for this was Issue #446. This was fixed with a few lines of code using built in python classes that the documentation describes as being used for this exact situation. 

I had to add a return object to the configure_logger() function. It now also return the [QueueListener](https://github.com/bpnordin/Twitch-Channel-Points-Miner-v2/blob/955b495dd713908a0f001291f6cf3184c8a7907e/TwitchChannelPointsMiner/logger.py#L219-L226). This was to allow the main thread to properly close the queue by handling all the messages before the program [exits](https://github.com/bpnordin/Twitch-Channel-Points-Miner-v2/blob/955b495dd713908a0f001291f6cf3184c8a7907e/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py#L352-L355). 



Fixes #446 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

I got the thread ID of the main thread, and verified that the discord messages were being sent on a different thread. This would confirm that the hang up of the webhooks will not effect the main thread. The original issue was had by @[MPThLee](https://github.com/MPThLee). They could see if this fixes the issues they were having. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
