### PR TITLE
Support for 2+ outcomes

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -429,8 +429,7 @@ class Twitch(object):
 
     def make_predictions(self, event):
         decision = event.bet.calculate(event.streamer.channel_points)
-        selector_index = 0 if decision["choice"] == "A" else 1
-
+        
         logger.info(
             f"Going to complete bet for {event}",
             extra={
@@ -458,7 +457,7 @@ class Twitch(object):
             else:
                 if decision["amount"] >= 10:
                     logger.info(
-                        f"Place {_millify(decision['amount'])} channel points on: {event.bet.get_outcome(selector_index)}",
+                        f"Place {_millify(decision['amount'])} channel points on: {event.bet.get_outcome(decision['choice'])}",
                         extra={
                             "emoji": ":four_leaf_clover:",
                             "event": Events.BET_GENERAL,

--- a/TwitchChannelPointsMiner/classes/entities/Bet.py
+++ b/TwitchChannelPointsMiner/classes/entities/Bet.py
@@ -4,7 +4,7 @@ from random import uniform
 
 from millify import millify
 
-from TwitchChannelPointsMiner.utils import char_decision_as_index, float_round
+from TwitchChannelPointsMiner.utils import float_round
 
 
 class Strategy(Enum):

--- a/TwitchChannelPointsMiner/classes/entities/Bet.py
+++ b/TwitchChannelPointsMiner/classes/entities/Bet.py
@@ -154,19 +154,16 @@ class Bet(object):
                 top_points = outcomes[index]["top_predictors"][0]["points"]
                 self.outcomes[index][OutcomeKeys.TOP_POINTS] = top_points
 
-        self.total_users = (
-            self.outcomes[0][OutcomeKeys.TOTAL_USERS]
-            + self.outcomes[1][OutcomeKeys.TOTAL_USERS]
-        )
-        self.total_points = (
-            self.outcomes[0][OutcomeKeys.TOTAL_POINTS]
-            + self.outcomes[1][OutcomeKeys.TOTAL_POINTS]
-        )
+        #inefficient but otherwise outcomekeys are represented wrong.
+        self.total_points = 0
+        self.total_users = 0
+        for index in range(0, len(self.outcomes)):
+            self.total_users += self.outcomes[index][OutcomeKeys.TOTAL_USERS]
+            self.total_points += self.outcomes[index][OutcomeKeys.TOTAL_POINTS]
 
         if (
             self.total_users > 0
-            and self.outcomes[0][OutcomeKeys.TOTAL_POINTS] > 0
-            and self.outcomes[1][OutcomeKeys.TOTAL_POINTS] > 0
+            and self.total_points > 0
         ):
             for index in range(0, len(self.outcomes)):
                 self.outcomes[index][OutcomeKeys.PERCENTAGE_USERS] = float_round(
@@ -174,10 +171,14 @@ class Bet(object):
                     / self.total_users
                 )
                 self.outcomes[index][OutcomeKeys.ODDS] = float_round(
-                    self.total_points / self.outcomes[index][OutcomeKeys.TOTAL_POINTS]
+                    0
+                    if self.outcomes[index][OutcomeKeys.TOTAL_POINTS] == 0
+                    else self.total_points / self.outcomes[index][OutcomeKeys.TOTAL_POINTS]
                 )
                 self.outcomes[index][OutcomeKeys.ODDS_PERCENTAGE] = float_round(
-                    100 / self.outcomes[index][OutcomeKeys.ODDS]
+                    0
+                    if self.outcomes[index][OutcomeKeys.ODDS] == 0
+                    else 100 / self.outcomes[index][OutcomeKeys.ODDS]
                 )
 
         self.__clear_outcomes()
@@ -186,7 +187,7 @@ class Bet(object):
         return f"Bet(total_users={millify(self.total_users)}, total_points={millify(self.total_points)}), decision={self.decision})\n\t\tOutcome A({self.get_outcome(0)})\n\t\tOutcome B({self.get_outcome(1)})"
 
     def get_decision(self, parsed=False):
-        decision = self.outcomes[0 if self.decision["choice"] == "A" else 1]
+        decision = self.outcomes[self.decision["choice"]]
         return decision if parsed is False else Bet.__parse_outcome(decision)
 
     @staticmethod
@@ -221,8 +222,12 @@ class Bet(object):
                 if key not in self.outcomes[index]:
                     self.outcomes[index][key] = 0
 
-    def __return_choice(self, key) -> str:
-        return "A" if self.outcomes[0][key] > self.outcomes[1][key] else "B"
+    def __return_choice(self, key) -> int:
+        largest=0
+        for index in range(0, len(self.outcomes)):
+            if self.outcomes[index][key] > self.outcomes[largest][key]:
+                largest = index
+        return largest
 
     def skip(self) -> bool:
         if self.settings.filter_condition is not None:
@@ -241,7 +246,7 @@ class Bet(object):
                     self.outcomes[0][fixed_key] + self.outcomes[1][fixed_key]
                 )
             else:
-                outcome_index = char_decision_as_index(self.decision["choice"])
+                outcome_index = self.decision["choice"]
                 compared_value = self.outcomes[outcome_index][fixed_key]
 
             # Check if condition is satisfied
@@ -283,7 +288,7 @@ class Bet(object):
             )
 
         if self.decision["choice"] is not None:
-            index = char_decision_as_index(self.decision["choice"])
+            index = self.decision["choice"]
             self.decision["id"] = self.outcomes[index]["id"]
             self.decision["amount"] = min(
                 int(balance * (self.settings.percentage / 100)),


### PR DESCRIPTION
# Description

Implements basic support for predictions with more than two potential outcomes. Part of the fix included modifying how choices were interpreted by changing decision["choice"] to be the index rather than a letter being used as intermediary.

Basic safeguards for the divide by zero error were added in as well.

Fixes #497 
Limited support for predictions with more than 2 outcomes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested 4-5 times on predictions with more than 2 outcomes, most of which utilizing 10 (the new limit).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
