### PR TITLE
Migrate emoji to v2.0.0

### DIFF
--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -111,7 +111,7 @@ class GlobalFormatter(logging.Formatter):
             and record.emoji_is_present is False
         ):
             record.msg = emoji.emojize(
-                f"{record.emoji}  {record.msg.strip()}", use_aliases=True
+                f"{record.emoji}  {record.msg.strip()}", language="alias"
             )
             record.emoji_is_present = True
 


### PR DESCRIPTION
# Description
Migrate emoji python package to v2.0.0.
 - Remove the emojize() deprecated parameters "use_aliases" and change it into "language"
I think it's not backward compatible with this fix.

Fixes #549 #550

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tested it on my ubuntu 20.04 server, and it works fine.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been updated in requirements.txt
