### PR TITLE
Fix divide by 0 issues during betting calculations

### DIFF
--- a/TwitchChannelPointsMiner/classes/entities/Bet.py
+++ b/TwitchChannelPointsMiner/classes/entities/Bet.py
@@ -171,13 +171,13 @@ class Bet(object):
             for index in range(0, len(self.outcomes)):
                 self.outcomes[index][OutcomeKeys.PERCENTAGE_USERS] = float_round(
                     (100 * self.outcomes[index][OutcomeKeys.TOTAL_USERS])
-                    / self.total_users
+                    / min(self.total_users, 1)
                 )
                 self.outcomes[index][OutcomeKeys.ODDS] = float_round(
-                    self.total_points / self.outcomes[index][OutcomeKeys.TOTAL_POINTS]
+                    self.total_points / min(self.outcomes[index][OutcomeKeys.TOTAL_POINTS], 1)
                 )
                 self.outcomes[index][OutcomeKeys.ODDS_PERCENTAGE] = float_round(
-                    100 / self.outcomes[index][OutcomeKeys.ODDS]
+                    100 / min(self.outcomes[index][OutcomeKeys.ODDS], 1)
                 )
 
         self.__clear_outcomes()

--- a/TwitchChannelPointsMiner/classes/entities/Bet.py
+++ b/TwitchChannelPointsMiner/classes/entities/Bet.py
@@ -171,13 +171,13 @@ class Bet(object):
             for index in range(0, len(self.outcomes)):
                 self.outcomes[index][OutcomeKeys.PERCENTAGE_USERS] = float_round(
                     (100 * self.outcomes[index][OutcomeKeys.TOTAL_USERS])
-                    / min(self.total_users, 1)
+                    / max(self.total_users, 1)
                 )
                 self.outcomes[index][OutcomeKeys.ODDS] = float_round(
-                    self.total_points / min(self.outcomes[index][OutcomeKeys.TOTAL_POINTS], 1)
+                    self.total_points / max(self.outcomes[index][OutcomeKeys.TOTAL_POINTS], 1)
                 )
                 self.outcomes[index][OutcomeKeys.ODDS_PERCENTAGE] = float_round(
-                    100 / min(self.outcomes[index][OutcomeKeys.ODDS], 1)
+                    100 / max(self.outcomes[index][OutcomeKeys.ODDS], 1)
                 )
 
         self.__clear_outcomes()


### PR DESCRIPTION
# What
This PR aims to avoid inadvertent divide by 0 errors by clamping the minimum divide values to 1 while betting as a defensive measure

# Why
Currently bet.py can trigger divide by 0 errors under certain scenarios. In theory given we are calculating percentages / decimal probabilities in this part of the code all dividing values should be > 0 in either case.
```
Traceback (most recent call last):
  File "/usr/src/app/TwitchChannelPointsMiner/classes/WebSocketsPool.py", line 310, in on_message
    ws.events_predictions[event_id].bet.update_outcomes(
  File "/usr/src/app/TwitchChannelPointsMiner/classes/entities/Bet.py", line 177, in update_outcomes
    self.total_points / self.outcomes[index][OutcomeKeys.TOTAL_POINTS]
ZeroDivisionError: division by zero
``` 

This should hopefully raise the stability of the script in edge cases

# How
By clamping any values we use for calculating the values to divide to by to one and above

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md) (N/a)
- [ ] My changes generate no new warnings (N/a)
- [ ] Any dependent changes have been updated in requirements.txt (N/a)
