### PR TITLE
Handle 2FA Cookie in the `run.py`

### DIFF
--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -71,6 +71,7 @@ class TwitchChannelPointsMiner:
         self,
         username: str,
         password: str = None,
+        auth_token: str = None,
         claim_drops_startup: bool = False,
         # Settings for logging and selenium as you can see.
         priority: list = [Priority.STREAK, Priority.DROPS, Priority.ORDER],
@@ -93,7 +94,7 @@ class TwitchChannelPointsMiner:
         Settings.streamer_settings = streamer_settings
 
         user_agent = get_user_agent("FIREFOX")
-        self.twitch = Twitch(self.username, user_agent, password)
+        self.twitch = Twitch(self.username, user_agent, password, auth_token)
 
         self.claim_drops_startup = claim_drops_startup
         self.priority = priority if isinstance(priority, list) else [priority]

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -41,13 +41,13 @@ logger = logging.getLogger(__name__)
 class Twitch(object):
     __slots__ = ["cookies_file", "user_agent", "twitch_login", "running"]
 
-    def __init__(self, username, user_agent, password=None):
+    def __init__(self, username, user_agent, password=None, auth_token=None):
         cookies_path = os.path.join(Path().absolute(), "cookies")
         Path(cookies_path).mkdir(parents=True, exist_ok=True)
         self.cookies_file = os.path.join(cookies_path, f"{username}.pkl")
         self.user_agent = user_agent
         self.twitch_login = TwitchLogin(
-            CLIENT_ID, username, self.user_agent, password=password
+            CLIENT_ID, username, self.user_agent, password=password, auth_token=auth_token,
         )
         self.running = True
 

--- a/TwitchChannelPointsMiner/classes/TwitchLogin.py
+++ b/TwitchChannelPointsMiner/classes/TwitchLogin.py
@@ -34,7 +34,7 @@ class TwitchLogin(object):
         "cookies",
     ]
 
-    def __init__(self, client_id, username, user_agent, password=None):
+    def __init__(self, client_id, username, user_agent, password=None, auth_token=None):
         self.client_id = client_id
         self.token = None
         self.login_check_result = False
@@ -131,7 +131,7 @@ class TwitchLogin(object):
                         )
 
                 if "access_token" in login_response:
-                    self.set_token(login_response["access_token"])
+                    self.set_token(login_response["access_token"] or auth_token)
                     return self.check_login()
 
             if use_backup_flow:

--- a/example.py
+++ b/example.py
@@ -14,6 +14,7 @@ from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer, Streame
 twitch_miner = TwitchChannelPointsMiner(
     username="your-twitch-username",
     password="write-your-secure-psw",           # If no password will be provided, the script will ask interactively
+    auth_token="your-auth-token-twitch-cookie", # If you are unable to login due to 2FA issues, please define this as the `auth-token` cookie in your browser where you've previously logged into twitch.
     claim_drops_startup=False,                  # If you want to auto claim all drops from Twitch inventory on the startup
     priority=[                                  # Custom priority in this case for example:
         Priority.STREAK,                        # - We want first of all to catch all watch streak from all streamers


### PR DESCRIPTION
# Description

I've never written python before so please bare with me 😂 

As mentioned in [this issue](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/606#issuecomment-1266648613), there is a 'bug' where twitch will not let you sign in with 2FA incorrectly defined. In the same issue a fix is provided where you can override the contents of the `TwitchLogin.py` file to set the token. Unfortunately, this does not work for other implementations such as `docker-compose`. Therefore, I've gotten a bit of a headstart and written this PR to allow you to set your 2FA code the same way you do username and password, in the `run.py` file. 

Fixes #606 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been updated in requirements.txt
