### PR TITLE
Fix DelayMode.PERCENTAGE behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ Here's a concrete example. Let's suppose we have a bet that is opened with a tim
 
 - **FROM_START** with `delay=20`: The bet will be placed 20s after the bet is opened
 - **FROM_END** with `delay=20`: The bet will be placed 20s before the end of the bet (so 9mins 40s after the bet is opened)
-- **PERCENTAGE** with `delay=0.2`: The bet will be placed when the timer went down by 20% (so 2mins after the bet is opened)
+- **PERCENTAGE** with `delay=20`: The bet will be placed when the timer went down by 20% (so 2mins after the bet is opened)
 
 ## Analytics
 We have recently introduced a little frontend where you can show with a chart you points trend. The script will spawn a Flask web-server on your machine where you can select binding address and port.

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -196,7 +196,7 @@ class Streamer(object):
         elif delay_mode == DelayMode.FROM_END:
             return max(prediction_window_seconds - delay, 0)
         elif delay_mode == DelayMode.PERCENTAGE:
-            return prediction_window_seconds * delay
+            return prediction_window_seconds * delay / 100
         else:
             return prediction_window_seconds
 


### PR DESCRIPTION
When DelayMode.PERCENTAGE is used, the expectation is that when n% of the points submission time for a prediction has elapsed, the bot will make its prediction. The current behaviour however, is that the total duration of a prediction is multiplied by the delay to calculate this. This way, the term 'Percentage' doesn't really make sense, as it acts as a multiplier and not a percentage (see "- **PERCENTAGE**: Will place the bet when `delay` percent of the set timer is elapsed" in the docs). 

example of current behaviour:
 - A prediction with a submission period of 90 seconds is started, with delay set to 75, and DelayMode.PERCENTAGE as the delay mode 
 - 6750 seconds (75*90) after the start of the prediction, the bot attempts to join the prediction

example of behaviour after this fix:
 - A prediction with a submission period of 90 seconds is started, with delay set to 75, and DelayMode.PERCENTAGE as the delay mode 
 - 67.5 seconds (75% of 90 seconds) after the start of the prediction, the bot attempts to join the prediction

[x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
Existing users would need to edit their configuration if they manually devided their percentage by 100 in their run.py. For those that did not manually adjust the percentage the bot would start working as intended.

Simple test is to run a couple of predictions with different submission lengths and seeing what delay the bot outputs to the terminal, and to check if the outputted delay corresponds with delay% of that submission length.  

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas 
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
